### PR TITLE
CSI-PowerScale: Leader lection timeout flag values in sync with helm

### DIFF
--- a/samples/isilon_v220_k8s_121.yaml
+++ b/samples/isilon_v220_k8s_121.yaml
@@ -193,7 +193,7 @@ spec:
 
     sideCars:
       - name: common
-        args: ["--leader-election-renew-deadline=15s", "--leader-election-lease-duration=20s", "--leader-election-retry-period=10s"]
+        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=5s"]
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]
       # Uncomment the following to install 'external-health-monitor' sidecar to enable health monitor of CSI volumes from Controller plugin.

--- a/samples/isilon_v220_k8s_122.yaml
+++ b/samples/isilon_v220_k8s_122.yaml
@@ -193,7 +193,7 @@ spec:
 
     sideCars:
       - name: common
-        args: ["--leader-election-renew-deadline=15s", "--leader-election-lease-duration=20s", "--leader-election-retry-period=10s"]
+        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=5s"]
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]
       # Uncomment the following to install 'external-health-monitor' sidecar to enable health monitor of CSI volumes from Controller plugin.

--- a/samples/isilon_v220_k8s_123.yaml
+++ b/samples/isilon_v220_k8s_123.yaml
@@ -193,7 +193,7 @@ spec:
 
     sideCars:
       - name: common
-        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=10s"]
+        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=5s"]
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]
       # Uncomment the following to install 'external-health-monitor' sidecar to enable health monitor of CSI volumes from Controller plugin.

--- a/samples/isilon_v220_k8s_123.yaml
+++ b/samples/isilon_v220_k8s_123.yaml
@@ -193,7 +193,7 @@ spec:
 
     sideCars:
       - name: common
-        args: ["--leader-election-renew-deadline=15s", "--leader-election-lease-duration=20s", "--leader-election-retry-period=10s"]
+        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=10s"]
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]
       # Uncomment the following to install 'external-health-monitor' sidecar to enable health monitor of CSI volumes from Controller plugin.

--- a/samples/isilon_v220_ops_48.yaml
+++ b/samples/isilon_v220_ops_48.yaml
@@ -176,7 +176,7 @@ spec:
 
     sideCars:
       - name: common
-        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=10s"]
+        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=5s"]
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]
 ---

--- a/samples/isilon_v220_ops_48.yaml
+++ b/samples/isilon_v220_ops_48.yaml
@@ -176,7 +176,7 @@ spec:
 
     sideCars:
       - name: common
-        args: ["--leader-election-renew-deadline=15s", "--leader-election-lease-duration=20s", "--leader-election-retry-period=10s"]
+        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=10s"]
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]
 ---

--- a/samples/isilon_v220_ops_49.yaml
+++ b/samples/isilon_v220_ops_49.yaml
@@ -176,7 +176,7 @@ spec:
 
     sideCars:
       - name: common
-        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=10s"]
+        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=5s"]
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]
 ---

--- a/samples/isilon_v220_ops_49.yaml
+++ b/samples/isilon_v220_ops_49.yaml
@@ -176,7 +176,7 @@ spec:
 
     sideCars:
       - name: common
-        args: ["--leader-election-renew-deadline=15s", "--leader-election-lease-duration=20s", "--leader-election-retry-period=10s"]
+        args: ["--leader-election-lease-duration=15s", "--leader-election-renew-deadline=10s", "--leader-election-retry-period=10s"]
       - name: provisioner
         args: ["--volume-name-prefix=csipscale"]
 ---


### PR DESCRIPTION
# Description
Leader election timeout flags were added for operator but the value was different from helm so updated the same to be in sync.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/209 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Only sample file values updated they are being reflected in the driver
- [x] unit tests are passing
