### PR TITLE
Feature 285 fs group policy

### DIFF
--- a/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
@@ -153,6 +153,7 @@ metadata:
               "configVersion": "v2.3.0",
               "dnsPolicy": "ClusterFirstWithHostNet",
               "forceUpdate": false,
+              "fsGroupPolicy": "ReadWriteOnceWithFSType",
               "node": {
                 "envs": [
                   {

--- a/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
+++ b/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
@@ -147,12 +147,13 @@ metadata:
                     "value": "4"
                   }
                 ],
-                "image": "dellemc/csi-powermax:v2.2.0",
+                "image": "dellemc/csi-powermax:v2.3.0",
                 "imagePullPolicy": "IfNotPresent"
               },
-              "configVersion": "v2.2.0",
+              "configVersion": "v2.3.0",
               "dnsPolicy": "ClusterFirstWithHostNet",
               "forceUpdate": false,
+              "fsGroupPolicy": "ReadWriteOnceWithFSType",
               "node": {
                 "envs": [
                   {

--- a/config/samples/storage_v1_csipowermax.yaml
+++ b/config/samples/storage_v1_csipowermax.yaml
@@ -14,6 +14,7 @@ spec:
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerMax driver v2.3.0
       image: dellemc/csi-powermax:v2.3.0

--- a/pkg/resources/csidriver/csidriver.go
+++ b/pkg/resources/csidriver/csidriver.go
@@ -35,7 +35,7 @@ func New(instance csiv1.CSIDriver, ephemeralEnabled bool, dummyClusterRole *rbac
 		VolumeLifecycleModes: modes,
 	}
 
-	if instance.GetDriverType() == "powerstore" || instance.GetDriverType() == "isilon" {
+	if instance.GetDriverType() == "powerstore" || instance.GetDriverType() == "isilon" || instance.GetDriverType() == "powermax" {
 		spec.FSGroupPolicy = &fsgroup
 	}
 

--- a/samples/powermax_revproxy_standalone_with_driver.yaml
+++ b/samples/powermax_revproxy_standalone_with_driver.yaml
@@ -77,6 +77,7 @@ spec:
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerMax driver v2.3.0
       image: dellemc/csi-powermax:v2.3.0

--- a/samples/powermax_v230_k8s_121.yaml
+++ b/samples/powermax_v230_k8s_121.yaml
@@ -14,6 +14,7 @@ spec:
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerMax driver v2.3.0
       image: dellemc/csi-powermax:v2.3.0

--- a/samples/powermax_v230_k8s_122.yaml
+++ b/samples/powermax_v230_k8s_122.yaml
@@ -14,6 +14,7 @@ spec:
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerMax driver v2.3.0
       image: dellemc/csi-powermax:v2.3.0

--- a/samples/powermax_v230_k8s_123.yaml
+++ b/samples/powermax_v230_k8s_123.yaml
@@ -14,6 +14,7 @@ spec:
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerMax driver v2.3.0
       image: dellemc/csi-powermax:v2.3.0

--- a/samples/powermax_v230_ops_410.yaml
+++ b/samples/powermax_v230_ops_410.yaml
@@ -14,6 +14,7 @@ spec:
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerMax driver v2.3.0
       image: dellemc/csi-powermax:v2.3.0

--- a/samples/powermax_v230_ops_49.yaml
+++ b/samples/powermax_v230_ops_49.yaml
@@ -14,6 +14,7 @@ spec:
     replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerMax driver v2.3.0
       image: dellemc/csi-powermax:v2.3.0

--- a/test/testdata/csipowermax/01-simple-deployment/out-csidriver.yaml
+++ b/test/testdata/csipowermax/01-simple-deployment/out-csidriver.yaml
@@ -11,5 +11,6 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
+  fsGroupPolicy: "ReadWriteOnceWithFSType"
   volumeLifecycleModes:
     - Persistent


### PR DESCRIPTION
Added the option for user to configure fsGroup policy support.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/285 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Installed the Operator and executed e2e tests for FsGroup policy
#############################################
![driver_install](https://user-images.githubusercontent.com/92081029/168024041-98781e8d-9b8f-499b-849b-d20fff255bd5.png)

![e2e_logs](https://user-images.githubusercontent.com/92081029/168024076-429658f8-d855-482b-bb53-f9a83ca24973.png)
