### PR TITLE
Adds support for Custom Topology keys 

### DIFF
--- a/driverconfig/powermax_v230_v121.json
+++ b/driverconfig/powermax_v230_v121.json
@@ -253,6 +253,22 @@
         "SetForNode": true,
         "DefaultValueForController": "false",
         "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_TOPOLOGY_CONTROL_ENABLED",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_TOPOLOGY_CONFIG_PATH",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/node-topology-config/topologyConfig.yaml"
       }
     ],
     "driverNodeVolumes": [
@@ -324,6 +340,12 @@
         "name": "powermax-config-params",
         "configMap": {
           "name": "powermax-config-params"
+        }
+      },
+      {
+        "name": "node-topology-config",
+        "configMap": {
+          "name": "node-topology-config"
         }
       }
     ],
@@ -401,6 +423,10 @@
       {
         "mountPath": "/powermax-config-params",
         "name": "powermax-config-params"
+      },
+      {
+        "mountPath": "/node-topology-config",
+        "name": "node-topology-config"
       }
     ],
     "sidecarParams": [

--- a/driverconfig/powermax_v230_v122.json
+++ b/driverconfig/powermax_v230_v122.json
@@ -253,6 +253,22 @@
         "SetForNode": true,
         "DefaultValueForController": "false",
         "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_TOPOLOGY_CONTROL_ENABLED",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_TOPOLOGY_CONFIG_PATH",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/node-topology-config/topologyConfig.yaml"
       }
     ],
     "driverNodeVolumes": [
@@ -324,6 +340,12 @@
         "name": "powermax-config-params",
         "configMap": {
           "name": "powermax-config-params"
+        }
+      },
+      {
+        "name": "node-topology-config",
+        "configMap": {
+          "name": "node-topology-config"
         }
       }
     ],
@@ -401,6 +423,10 @@
       {
         "mountPath": "/powermax-config-params",
         "name": "powermax-config-params"
+      },
+      {
+        "mountPath": "/node-topology-config",
+        "name": "node-topology-config"
       }
     ],
     "sidecarParams": [

--- a/driverconfig/powermax_v230_v123.json
+++ b/driverconfig/powermax_v230_v123.json
@@ -253,6 +253,22 @@
         "SetForNode": true,
         "DefaultValueForController": "false",
         "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_TOPOLOGY_CONTROL_ENABLED",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_TOPOLOGY_CONFIG_PATH",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/node-topology-config/topologyConfig.yaml"
       }
     ],
     "driverNodeVolumes": [
@@ -324,6 +340,12 @@
         "name": "powermax-config-params",
         "configMap": {
           "name": "powermax-config-params"
+        }
+      },
+      {
+        "name": "node-topology-config",
+        "configMap": {
+          "name": "node-topology-config"
         }
       }
     ],
@@ -401,6 +423,10 @@
       {
         "mountPath": "/powermax-config-params",
         "name": "powermax-config-params"
+      },
+      {
+        "mountPath": "/node-topology-config",
+        "name": "node-topology-config"
       }
     ],
     "sidecarParams": [

--- a/samples/powermax_revproxy_standalone_with_driver.yaml
+++ b/samples/powermax_revproxy_standalone_with_driver.yaml
@@ -165,6 +165,14 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
 
     sideCars:
       # Uncomment the following to install 'external-health-monitor' sidecar to enable health monitor of CSI volumes from Controller plugin.
@@ -182,3 +190,49 @@ data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "debug"
     CSI_LOG_FORMAT: "JSON"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-topology-config
+  namespace: test-powermax
+data:
+  topologyConfig.yaml: |
+    # allowedConnections contains a list of (node, array and protocol) info for user allowed configuration
+    # For any given storage array ID and protocol on a Node, topology keys will be created for just those pair and
+    # every other configuration is ignored
+    # Please refer to the doc website about a detailed explanation of each configuration parameter
+    # and the various possible inputs
+    allowedConnections:
+      # nodeName: Name of the node on which user wants to apply given rules
+      # Allowed values:
+      # nodeName - name of a specific node
+      # * -  all the nodes
+      # Examples: "node1", "*"
+      - nodeName: "node1"
+        # rules is a list of 'StorageArrayID:TransportProtocol' pair. ':' is required between both value
+        # Allowed values:
+        # StorageArrayID:
+        #   - SymmetrixID : for specific storage array
+        #   - "*" :- for all the arrays connected to the node
+        # TransportProtocol:
+        #   - FC : Fibre Channel protocol
+        #   - ISCSI : iSCSI protocol
+        #   - "*" - for all the possible Transport Protocol
+        # Examples: "000000000001:FC", "000000000002:*", "*:FC", "*:*"
+        rules:
+          - "000000000001:FC"
+          - "000000000002:FC"
+      - nodeName: "*"
+        rules:
+          - "000000000002:FC"
+    # deniedConnections contains a list of (node, array and protocol) info for denied configurations by user
+    # For any given storage array ID and protocol on a Node, topology keys will be created for every other configuration but
+    # not these input pairs
+    deniedConnections:
+      - nodeName: "node2"
+        rules:
+          - "000000000002:*"
+      - nodeName: "node3"
+        rules:
+          - "*:*"

--- a/samples/powermax_v230_k8s_121.yaml
+++ b/samples/powermax_v230_k8s_121.yaml
@@ -110,6 +110,14 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -120,3 +128,49 @@ data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "debug"
     CSI_LOG_FORMAT: "JSON"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-topology-config
+  namespace: test-powermax
+data:
+  topologyConfig.yaml: |
+    # allowedConnections contains a list of (node, array and protocol) info for user allowed configuration
+    # For any given storage array ID and protocol on a Node, topology keys will be created for just those pair and
+    # every other configuration is ignored
+    # Please refer to the doc website about a detailed explanation of each configuration parameter
+    # and the various possible inputs
+    allowedConnections:
+      # nodeName: Name of the node on which user wants to apply given rules
+      # Allowed values:
+      # nodeName - name of a specific node
+      # * -  all the nodes
+      # Examples: "node1", "*"
+      - nodeName: "node1"
+        # rules is a list of 'StorageArrayID:TransportProtocol' pair. ':' is required between both value
+        # Allowed values:
+        # StorageArrayID:
+        #   - SymmetrixID : for specific storage array
+        #   - "*" :- for all the arrays connected to the node
+        # TransportProtocol:
+        #   - FC : Fibre Channel protocol
+        #   - ISCSI : iSCSI protocol
+        #   - "*" - for all the possible Transport Protocol
+        # Examples: "000000000001:FC", "000000000002:*", "*:FC", "*:*"
+        rules:
+          - "000000000001:FC"
+          - "000000000002:FC"
+      - nodeName: "*"
+        rules:
+          - "000000000002:FC"
+    # deniedConnections contains a list of (node, array and protocol) info for denied configurations by user
+    # For any given storage array ID and protocol on a Node, topology keys will be created for every other configuration but
+    # not these input pairs
+    deniedConnections:
+      - nodeName: "node2"
+        rules:
+          - "000000000002:*"
+      - nodeName: "node3"
+        rules:
+          - "*:*"

--- a/samples/powermax_v230_k8s_122.yaml
+++ b/samples/powermax_v230_k8s_122.yaml
@@ -110,6 +110,14 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -120,3 +128,49 @@ data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "debug"
     CSI_LOG_FORMAT: "JSON"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-topology-config
+  namespace: test-powermax
+data:
+  topologyConfig.yaml: |
+    # allowedConnections contains a list of (node, array and protocol) info for user allowed configuration
+    # For any given storage array ID and protocol on a Node, topology keys will be created for just those pair and
+    # every other configuration is ignored
+    # Please refer to the doc website about a detailed explanation of each configuration parameter
+    # and the various possible inputs
+    allowedConnections:
+      # nodeName: Name of the node on which user wants to apply given rules
+      # Allowed values:
+      # nodeName - name of a specific node
+      # * -  all the nodes
+      # Examples: "node1", "*"
+      - nodeName: "node1"
+        # rules is a list of 'StorageArrayID:TransportProtocol' pair. ':' is required between both value
+        # Allowed values:
+        # StorageArrayID:
+        #   - SymmetrixID : for specific storage array
+        #   - "*" :- for all the arrays connected to the node
+        # TransportProtocol:
+        #   - FC : Fibre Channel protocol
+        #   - ISCSI : iSCSI protocol
+        #   - "*" - for all the possible Transport Protocol
+        # Examples: "000000000001:FC", "000000000002:*", "*:FC", "*:*"
+        rules:
+          - "000000000001:FC"
+          - "000000000002:FC"
+      - nodeName: "*"
+        rules:
+          - "000000000002:FC"
+    # deniedConnections contains a list of (node, array and protocol) info for denied configurations by user
+    # For any given storage array ID and protocol on a Node, topology keys will be created for every other configuration but
+    # not these input pairs
+    deniedConnections:
+      - nodeName: "node2"
+        rules:
+          - "000000000002:*"
+      - nodeName: "node3"
+        rules:
+          - "*:*"

--- a/samples/powermax_v230_k8s_123.yaml
+++ b/samples/powermax_v230_k8s_123.yaml
@@ -110,6 +110,14 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -120,3 +128,49 @@ data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "debug"
     CSI_LOG_FORMAT: "JSON"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-topology-config
+  namespace: test-powermax
+data:
+  topologyConfig.yaml: |
+    # allowedConnections contains a list of (node, array and protocol) info for user allowed configuration
+    # For any given storage array ID and protocol on a Node, topology keys will be created for just those pair and
+    # every other configuration is ignored
+    # Please refer to the doc website about a detailed explanation of each configuration parameter
+    # and the various possible inputs
+    allowedConnections:
+      # nodeName: Name of the node on which user wants to apply given rules
+      # Allowed values:
+      # nodeName - name of a specific node
+      # * -  all the nodes
+      # Examples: "node1", "*"
+      - nodeName: "node1"
+        # rules is a list of 'StorageArrayID:TransportProtocol' pair. ':' is required between both value
+        # Allowed values:
+        # StorageArrayID:
+        #   - SymmetrixID : for specific storage array
+        #   - "*" :- for all the arrays connected to the node
+        # TransportProtocol:
+        #   - FC : Fibre Channel protocol
+        #   - ISCSI : iSCSI protocol
+        #   - "*" - for all the possible Transport Protocol
+        # Examples: "000000000001:FC", "000000000002:*", "*:FC", "*:*"
+        rules:
+          - "000000000001:FC"
+          - "000000000002:FC"
+      - nodeName: "*"
+        rules:
+          - "000000000002:FC"
+    # deniedConnections contains a list of (node, array and protocol) info for denied configurations by user
+    # For any given storage array ID and protocol on a Node, topology keys will be created for every other configuration but
+    # not these input pairs
+    deniedConnections:
+      - nodeName: "node2"
+        rules:
+          - "000000000002:*"
+      - nodeName: "node3"
+        rules:
+          - "*:*"

--- a/samples/powermax_v230_ops_410.yaml
+++ b/samples/powermax_v230_ops_410.yaml
@@ -86,6 +86,14 @@ spec:
         # Default value: "false"
         - name: "X_CSI_POWERMAX_ISCSI_ENABLE_CHAP"
           value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -96,3 +104,49 @@ data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "debug"
     CSI_LOG_FORMAT: "JSON"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-topology-config
+  namespace: test-powermax
+data:
+  topologyConfig.yaml: |
+    # allowedConnections contains a list of (node, array and protocol) info for user allowed configuration
+    # For any given storage array ID and protocol on a Node, topology keys will be created for just those pair and
+    # every other configuration is ignored
+    # Please refer to the doc website about a detailed explanation of each configuration parameter
+    # and the various possible inputs
+    allowedConnections:
+      # nodeName: Name of the node on which user wants to apply given rules
+      # Allowed values:
+      # nodeName - name of a specific node
+      # * -  all the nodes
+      # Examples: "node1", "*"
+      - nodeName: "node1"
+        # rules is a list of 'StorageArrayID:TransportProtocol' pair. ':' is required between both value
+        # Allowed values:
+        # StorageArrayID:
+        #   - SymmetrixID : for specific storage array
+        #   - "*" :- for all the arrays connected to the node
+        # TransportProtocol:
+        #   - FC : Fibre Channel protocol
+        #   - ISCSI : iSCSI protocol
+        #   - "*" - for all the possible Transport Protocol
+        # Examples: "000000000001:FC", "000000000002:*", "*:FC", "*:*"
+        rules:
+          - "000000000001:FC"
+          - "000000000002:FC"
+      - nodeName: "*"
+        rules:
+          - "000000000002:FC"
+    # deniedConnections contains a list of (node, array and protocol) info for denied configurations by user
+    # For any given storage array ID and protocol on a Node, topology keys will be created for every other configuration but
+    # not these input pairs
+    deniedConnections:
+      - nodeName: "node2"
+        rules:
+          - "000000000002:*"
+      - nodeName: "node3"
+        rules:
+          - "*:*"

--- a/samples/powermax_v230_ops_49.yaml
+++ b/samples/powermax_v230_ops_49.yaml
@@ -86,6 +86,14 @@ spec:
         # Default value: "false"
         - name: "X_CSI_POWERMAX_ISCSI_ENABLE_CHAP"
           value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -96,3 +104,49 @@ data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "debug"
     CSI_LOG_FORMAT: "JSON"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-topology-config
+  namespace: test-powermax
+data:
+  topologyConfig.yaml: |
+    # allowedConnections contains a list of (node, array and protocol) info for user allowed configuration
+    # For any given storage array ID and protocol on a Node, topology keys will be created for just those pair and
+    # every other configuration is ignored
+    # Please refer to the doc website about a detailed explanation of each configuration parameter
+    # and the various possible inputs
+    allowedConnections:
+      # nodeName: Name of the node on which user wants to apply given rules
+      # Allowed values:
+      # nodeName - name of a specific node
+      # * -  all the nodes
+      # Examples: "node1", "*"
+      - nodeName: "node1"
+        # rules is a list of 'StorageArrayID:TransportProtocol' pair. ':' is required between both value
+        # Allowed values:
+        # StorageArrayID:
+        #   - SymmetrixID : for specific storage array
+        #   - "*" :- for all the arrays connected to the node
+        # TransportProtocol:
+        #   - FC : Fibre Channel protocol
+        #   - ISCSI : iSCSI protocol
+        #   - "*" - for all the possible Transport Protocol
+        # Examples: "000000000001:FC", "000000000002:*", "*:FC", "*:*"
+        rules:
+          - "000000000001:FC"
+          - "000000000002:FC"
+      - nodeName: "*"
+        rules:
+          - "000000000002:FC"
+    # deniedConnections contains a list of (node, array and protocol) info for denied configurations by user
+    # For any given storage array ID and protocol on a Node, topology keys will be created for every other configuration but
+    # not these input pairs
+    deniedConnections:
+      - nodeName: "node2"
+        rules:
+          - "000000000002:*"
+      - nodeName: "node3"
+        rules:
+          - "*:*"

--- a/test/testdata/csipowermax/01-simple-deployment/out-daemonset.yaml
+++ b/test/testdata/csipowermax/01-simple-deployment/out-daemonset.yaml
@@ -80,6 +80,10 @@ spec:
               value: /powermax-config-params/driver-config-params.yaml
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "false"
+            - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+              value: "false"
+            - name: X_CSI_POWERMAX_TOPOLOGY_CONFIG_PATH
+              value: /node-topology-config/topologyConfig.yaml
             - name: X_CSI_POWERMAX_PORTGROUPS
               value: ""
           image: dellemc/csi-powermax:v2.3.0
@@ -115,6 +119,8 @@ spec:
               name: dbus-socket
             - mountPath: /powermax-config-params
               name: powermax-config-params
+            - mountPath: /node-topology-config
+              name: node-topology-config
         - args:
             - --v=5
             - --csi-address=$(ADDRESS)
@@ -196,6 +202,9 @@ spec:
         - name: powermax-config-params
           configMap:
             name: powermax-config-params
+        - name: node-topology-config
+          configMap:
+            name: node-topology-config
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1


### PR DESCRIPTION
# Description
This PR:
-
* Adds topology control based on config maps
* Adds the ability to allow or deny ( arrays & protocol ) on given nodes.
* Adds unit tests
* Adds sample config map

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/293 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
- [X] Unit Testing:
    _$~ make unit-test
    go clean -cache; cd ./test; go test -race -cover -coverprofile=coverage.out -coverpkg ../pkg/... ./. 2>&1 | tee test-result
    ok      github.com/dell/dell-csi-operator/test  14.221s coverage: 60.7% of statements in ../pkg/..._   
- [] Cluster Testing: