### PR TITLE
Adding support to k8 1.24 for powermax

### DIFF
--- a/driverconfig/config.yaml
+++ b/driverconfig/config.yaml
@@ -20,9 +20,9 @@ drivers:
       - configVersion: v2.2.0
         useDefaults: false
         supportedVersions:
-          - version: v120
           - version: v121
           - version: v122
+          - version: v123
         attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
         provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
         snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
@@ -38,23 +38,6 @@ drivers:
         provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
         snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
         resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-        registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
-      - configVersion: v2.0.0
-        useDefaults: false
-        supportedVersions:
-          - version: v119
-            provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
-            attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
-            snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
-            resizer: quay.io/k8scsi/csi-resizer:v1.1.0
-            registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
-          - version: v120
-          - version: v121
-          - version: v122
-        attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
-        provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
-        snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
-        resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
         registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
   - name: unity
     configVersions:

--- a/driverconfig/config.yaml
+++ b/driverconfig/config.yaml
@@ -16,6 +16,7 @@ drivers:
           - version: v121
           - version: v122
           - version: v123
+          - version: v124
       - configVersion: v2.2.0
         useDefaults: false
         supportedVersions:

--- a/driverconfig/powermax_v230_v124.json
+++ b/driverconfig/powermax_v230_v124.json
@@ -1,0 +1,612 @@
+{
+  "driverConfig": {
+    "controllerHA" : true,
+    "nodeTolerations": [
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/memory-pressure",
+        "operator": "Exists"
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/disk-pressure",
+        "operator": "Exists"
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/network-unavailable",
+        "operator": "Exists"
+      }
+    ],
+    "driverEnvs": [
+      {
+        "Name": "X_CSI_POWERMAX_DRIVER_NAME",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "csi-powermax.dellemc.com",
+        "DefaultValueForNode": "csi-powermax.dellemc.com"
+      },
+      {
+        "Name": "CSI_ENDPOINT",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "/var/run/csi/csi.sock",
+        "DefaultValueForNode": "unix:///var/lib/kubelet/plugins/powermax.emc.dell.com/csi_sock"
+      },
+      {
+        "Name": "X_CSI_MANAGED_ARRAYS",
+        "Mandatory": true,
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_POWERMAX_ENDPOINT",
+        "Mandatory": true,
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_K8S_CLUSTER_PREFIX",
+        "Mandatory": true,
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_MODE",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "controller",
+        "DefaultValueForNode": "node"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_SKIP_CERTIFICATE_VALIDATION",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "true",
+        "DefaultValueForNode": "true"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_USER",
+        "CSIEnvType": "EnvSecretReference",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "username/powermax-creds",
+        "DefaultValueForNode": "username/powermax-creds"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_PASSWORD",
+        "CSIEnvType": "EnvSecretReference",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "password/powermax-creds",
+        "DefaultValueForNode": "password/powermax-creds"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_ISCSI_CHAP_PASSWORD",
+        "CSIEnvType": "EnvSecretReference",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "chapsecret/powermax-creds"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_DEBUG",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_PORTGROUPS",
+        "CSIEnvType": "List",
+        "SetForController": true,
+        "SetForNode": false,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_ISCSI_CHROOT",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/noderoot"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_ARRAYS",
+        "CSIEnvType": "List",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_GRPC_MAX_THREADS",
+        "CSIEnvType": "Int",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "4",
+        "DefaultValueForNode": "4"
+      },
+      {
+        "Name": "X_CSI_ENABLE_BLOCK",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "true",
+        "DefaultValueForNode": "true"
+      },
+      {
+        "Name": "X_CSI_TRANSPORT_PROTOCOL",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_POWERMAX_NODENAME",
+        "CSIEnvType": "EnvVarReferenceType",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "v1/spec.nodeName"
+      },
+      {
+        "Name": "X_CSI_PRIVATE_MOUNT_DIR",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/var/lib/kubelet/plugins/powermax.emc.dell.com/disks"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_ISCSI_ENABLE_CHAP",
+        "CSIEnvType": "Boolean",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "SSL_CERT_DIR",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "/certs",
+        "DefaultValueForNode": "/certs"
+      },
+      {
+        "Name": "X_CSI_IG_NODENAME_TEMPLATE",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_IG_MODIFY_HOSTNAME",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_PROXY_SERVICE_NAME",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "none",
+        "DefaultValueForNode": "none"
+      },
+      {
+        "Name": "X_CSI_ReplicationContextPrefix",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": false,
+        "DefaultValueForController": "powermax/",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_ReplicationPrefix",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": false,
+        "DefaultValueForController": "replication.storage.dell.com/",
+        "DefaultValueForNode": ""
+      },
+      {
+        "Name": "X_CSI_UNISPHERE_TIMEOUT",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "5m",
+        "DefaultValueForNode": "5m"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_CONFIG_PATH",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "/powermax-config-params/driver-config-params.yaml",
+        "DefaultValueForNode": "/powermax-config-params/driver-config-params.yaml"
+      },
+      {
+        "Name": "X_CSI_HEALTH_MONITOR_ENABLED",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_TOPOLOGY_CONTROL_ENABLED",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_POWERMAX_TOPOLOGY_CONFIG_PATH",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/node-topology-config/topologyConfig.yaml"
+      }
+    ],
+    "driverNodeVolumes": [
+      {
+        "hostPath": {
+          "path": "/var/lib/kubelet/plugins_registry/",
+          "type": "DirectoryOrCreate"
+        },
+        "name": "registration-dir"
+      },
+      {
+        "hostPath": {
+          "path": "/var/lib/kubelet/plugins/powermax.emc.dell.com",
+          "type": "DirectoryOrCreate"
+        },
+        "name": "driver-path"
+      },
+      {
+        "hostPath": {
+          "path": "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices",
+          "type": "DirectoryOrCreate"
+        },
+        "name": "volumedevices-path"
+      },
+      {
+        "hostPath": {
+          "path": "/var/lib/kubelet/pods",
+          "type": "Directory"
+        },
+        "name": "pods-path"
+      },
+      {
+        "hostPath": {
+          "path": "/dev",
+          "type": "Directory"
+        },
+        "name": "dev"
+      },
+      {
+        "hostPath": {
+          "path": "/sys",
+          "type": "Directory"
+        },
+        "name": "sys"
+      },
+      {
+        "hostPath": {
+          "path": "/",
+          "type": "Directory"
+        },
+        "name": "noderoot"
+      },
+      {
+        "name": "certs",
+        "secret": {
+          "defaultMode": 420,
+          "secretName": "powermax-certs",
+          "optional": true
+        }
+      },
+      {
+        "name": "dbus-socket",
+        "hostPath": {
+          "path": "/run/dbus/system_bus_socket",
+          "type": "Socket"
+        }
+      },
+      {
+        "name": "powermax-config-params",
+        "configMap": {
+          "name": "powermax-config-params"
+        }
+      },
+      {
+        "name": "node-topology-config",
+        "configMap": {
+          "name": "node-topology-config"
+        }
+      }
+    ],
+    "driverControllerVolumes": [
+      {
+        "emptyDir": {},
+        "name": "socket-dir"
+      },
+      {
+        "name": "certs",
+        "secret": {
+          "defaultMode": 420,
+          "secretName": "powermax-certs",
+          "optional": true
+        }
+      },
+      {
+        "name": "powermax-config-params",
+        "configMap": {
+          "name": "powermax-config-params"
+        }
+      }
+    ],
+    "driverControllerVolumeMounts": [
+      {
+        "mountPath": "/var/run/csi",
+        "name": "socket-dir"
+      },
+      {
+        "mountPath": "/certs",
+        "name": "certs",
+        "readOnly": true
+      },
+      {
+        "mountPath": "/powermax-config-params",
+        "name": "powermax-config-params"
+      }
+    ],
+    "driverNodeVolumeMounts": [
+      {
+        "mountPath": "/var/lib/kubelet/plugins/powermax.emc.dell.com",
+        "name": "driver-path"
+      },
+      {
+        "mountPath": "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices",
+        "mountPropagation": "Bidirectional",
+        "name": "volumedevices-path"
+      },
+      {
+        "mountPath": "/var/lib/kubelet/pods",
+        "mountPropagation": "Bidirectional",
+        "name": "pods-path"
+      },
+      {
+        "mountPath": "/dev",
+        "name": "dev"
+      },
+      {
+        "mountPath": "/sys",
+        "name": "sys"
+      },
+      {
+        "mountPath": "/noderoot",
+        "name": "noderoot"
+      },
+      {
+        "mountPath": "/certs",
+        "name": "certs",
+        "readOnly": true
+      },
+      {
+        "name": "dbus-socket",
+        "mountPath": "/run/dbus/system_bus_socket"
+      },
+      {
+        "mountPath": "/powermax-config-params",
+        "name": "powermax-config-params"
+      },
+      {
+        "mountPath": "/node-topology-config",
+        "name": "node-topology-config"
+      }
+    ],
+    "sidecarParams": [
+      {
+        "name": "provisioner",
+        "args": [
+          "--csi-address=$(ADDRESS)",
+          "--volume-name-uuid-length=10",
+          "--timeout=180s",
+          "--worker-threads=6",
+          "--v=5",
+          "--volume-name-prefix=pmax",
+          "--default-fstype=ext4",
+          "--leader-election",
+          "--extra-create-metadata",
+          "--feature-gates=Topology=true"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      },
+      {
+        "name": "attacher",
+        "args": [
+          "--csi-address=$(ADDRESS)",
+          "--v=5",
+          "--timeout=180s",
+          "--worker-threads=6",
+          "--leader-election"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      },
+      {
+        "name": "snapshotter",
+        "args": [
+          "--v=5",
+          "--snapshot-name-uuid-length=10",
+          "--timeout=180s",
+          "--snapshot-name-prefix=pmsn",
+          "--csi-address=$(ADDRESS)",
+          "--leader-election"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      },
+      {
+        "name": "resizer",
+        "args": [
+          "--csi-address=$(ADDRESS)",
+          "--v=5",
+          "--timeout=180s",
+          "--leader-election"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      },
+      {
+        "name": "registrar",
+        "args": [
+          "--v=5",
+          "--csi-address=$(ADDRESS)",
+          "--kubelet-registration-path=/var/lib/kubelet/plugins/powermax.emc.dell.com/csi_sock"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/csi/csi_sock"
+          },
+          {
+            "name": "KUBE_NODE_NAME",
+            "valueFrom": {
+              "fieldRef": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.nodeName"
+              }
+            }
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/registration",
+            "name": "registration-dir"
+          },
+          {
+            "mountPath": "/csi",
+            "name": "driver-path"
+          }
+        ]
+      },
+      {
+        "name": "external-health-monitor",
+        "optional": true,
+        "args": [
+          "--csi-address=$(ADDRESS)",
+          "--timeout=180s",
+          "--v=5",
+          "--leader-election",
+          "--monitor-interval=60s",
+          "--enable-node-watcher=true",
+          "--http-endpoint=:8080"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      }
+    ],
+    "storageClassParams": [
+      {
+        "Name": "SYMID",
+        "Mandatory": true
+      },
+      {
+        "Name": "SRP",
+        "Mandatory": true
+      },
+      {
+        "Name": "ServiceLevel"
+      },
+      {
+        "Name": "FsType"
+      }
+    ],
+    "storageClassAttrs": [
+      {
+        "name": "allowVolumeExpansion",
+        "value": true
+      },
+      {
+        "name": "volumeBindingMode",
+        "value": "WaitForFirstConsumer"
+      }
+    ]
+  }
+}

--- a/samples/powermax_v230_k8s_124.yaml
+++ b/samples/powermax_v230_k8s_124.yaml
@@ -1,0 +1,177 @@
+apiVersion: storage.dell.com/v1
+kind: CSIPowerMax
+metadata:
+  name: test-powermax
+  namespace: test-powermax
+spec:
+  driver:
+    # Config version for CSI PowerMax v2.3.0 driver
+    configVersion: v2.3.0
+    # replica: Define the number of PowerMax controller nodes
+    # to deploy to the Kubernetes release
+    # Allowed values: n, where n > 0
+    # Default value: None
+    replicas: 2
+    dnsPolicy: ClusterFirstWithHostNet
+    forceUpdate: false
+    fsGroupPolicy: ReadWriteOnceWithFSType
+    common:
+      # Image for CSI PowerMax driver v2.3.0
+      image: dellemc/csi-powermax:v2.3.0
+      # imagePullPolicy: Policy to determine if the image should be pulled prior to starting the container.
+      # Allowed values:
+      #  Always: Always pull the image.
+      #  IfNotPresent: Only pull the image if it does not already exist on the node.
+      #  Never: Never pull the image.
+      # Default value: None
+      imagePullPolicy: IfNotPresent
+      envs:
+        # X_CSI_MANAGED_ARRAYS: Serial ID of the arrays that will be used for provisioning
+        # Default value: None
+        # Examples: "000000000001", "000000000002"
+        - name: X_CSI_MANAGED_ARRAYS
+          value: "000000000000,000000000001"
+        # X_CSI_POWERMAX_ENDPOINT: Address of the Unisphere server that is managing the PowerMax arrays
+        # Default value: None
+        # Example: https://0.0.0.1:8443
+        - name: X_CSI_POWERMAX_ENDPOINT
+          value: "https://0.0.0.0:8443/"
+        # X_CSI_K8S_CLUSTER_PREFIX: Define a prefix that is appended onto
+        # all resources created in the Array
+        # This should be unique per K8s/CSI deployment
+        # maximum length of this value is 3 characters
+        # Default value: None
+        # Examples: "XYZ", "EMC"
+        - name: X_CSI_K8S_CLUSTER_PREFIX
+          value: "XYZ"
+        # X_CSI_POWERMAX_PORTGROUPS: Define the set of existing port groups that the driver will use.
+        # It is a comma separated list of portgroup names.
+        # Required only in case of iSCSI port groups
+        # Allowed values: iSCSI Port Group names
+        # Default value: None
+        # Examples: "pg1", "pg1, pg2"
+        - name: "X_CSI_POWERMAX_PORTGROUPS"
+          value: ""
+        # "X_CSI_TRANSPORT_PROTOCOL" can be "FC" or "FIBRE" for fibrechannel,
+        # "ISCSI" for iSCSI, or "" for autoselection.
+        # Allowed values:
+        #   "FC"    - Fiber Channel protocol
+        #   "FIBER" - Fiber Channel protocol
+        #   "ISCSI" - iSCSI protocol
+        #   ""      - Automatic selection of transport protocol
+        # Default value: "" <empty>
+        - name: "X_CSI_TRANSPORT_PROTOCOL"
+          value: ""
+        # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
+        # Set this to "powermax-reverseproxy" if you are installing the proxy
+        # Allowed values: "powermax-reverseproxy"
+        # default values: "" <empty>
+        - name: "X_CSI_POWERMAX_PROXY_SERVICE_NAME"
+          value: ""
+        # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.
+        # Set this value to a higher number (max 50) if you are using the proxy
+        # Allowed values: n, where n > 4
+        # default values: None
+        - name: "X_CSI_GRPC_MAX_THREADS"
+          value: "4"
+
+    sideCars:
+      # Uncomment the following to install 'external-health-monitor' sidecar to enable health monitor of CSI volumes from Controller plugin.
+      # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED to "true" for controller plugin.
+      # Also set the env variable node.envs.X_CSI_HEALTH_MONITOR_ENABLED to "true" for node plugin.
+      #- name: external-health-monitor
+      #  args: ["--monitor-interval=300s"]
+
+    controller:
+      envs:
+        # X_CSI_HEALTH_MONITOR_ENABLED: Determines if the controller plugin will monitor health of CSI volumes- volume status, volume condition
+        # Install the 'external-health-monitor' sidecar accordingly.
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+    node:
+      envs:
+        # X_CSI_POWERMAX_ISCSI_ENABLE_CHAP: Determine if the node plugin is going to configure
+        # ISCSI node databases on the nodes with the CHAP credentials
+        # If enabled, the CHAP secret must be provided in the credentials secret
+        # and set to the key "chapsecret"
+        # Allowed values:
+        #   "true"  - CHAP is enabled
+        #   "false" - CHAP is disabled
+        # Default value: "false"
+        - name: "X_CSI_POWERMAX_ISCSI_ENABLE_CHAP"
+          value: "false"
+        # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from node plugin- volume usage, volume condition
+        # Allowed values:
+        #   true: enable checking of health condition of CSI volumes
+        #   false: disable checking of health condition of CSI volumes
+        # Default value: false
+        - name: X_CSI_HEALTH_MONITOR_ENABLED
+          value: "false"
+        # X_CSI_TOPOLOGY_CONTROL_ENABLED provides a way to filter topology keys on a node based on array and transport protocol
+        # if enabled, user can create custom topology keys by editing node-topology-config configmap.
+        # Allowed values:
+        #   true: enable the filtration based on config map
+        #   false: disable the filtration based on config map
+        # Default value: false
+        - name: X_CSI_TOPOLOGY_CONTROL_ENABLED
+          value: "false"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: powermax-config-params
+  namespace: test-powermax
+data:
+  driver-config-params.yaml: |
+    CSI_LOG_LEVEL: "debug"
+    CSI_LOG_FORMAT: "JSON"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-topology-config
+  namespace: test-powermax
+data:
+  topologyConfig.yaml: |
+    # allowedConnections contains a list of (node, array and protocol) info for user allowed configuration
+    # For any given storage array ID and protocol on a Node, topology keys will be created for just those pair and
+    # every other configuration is ignored
+    # Please refer to the doc website about a detailed explanation of each configuration parameter
+    # and the various possible inputs
+    allowedConnections:
+      # nodeName: Name of the node on which user wants to apply given rules
+      # Allowed values:
+      # nodeName - name of a specific node
+      # * -  all the nodes
+      # Examples: "node1", "*"
+      - nodeName: "node1"
+        # rules is a list of 'StorageArrayID:TransportProtocol' pair. ':' is required between both value
+        # Allowed values:
+        # StorageArrayID:
+        #   - SymmetrixID : for specific storage array
+        #   - "*" :- for all the arrays connected to the node
+        # TransportProtocol:
+        #   - FC : Fibre Channel protocol
+        #   - ISCSI : iSCSI protocol
+        #   - "*" - for all the possible Transport Protocol
+        # Examples: "000000000001:FC", "000000000002:*", "*:FC", "*:*"
+        rules:
+          - "000000000001:FC"
+          - "000000000002:FC"
+      - nodeName: "*"
+        rules:
+          - "000000000002:FC"
+    # deniedConnections contains a list of (node, array and protocol) info for denied configurations by user
+    # For any given storage array ID and protocol on a Node, topology keys will be created for every other configuration but
+    # not these input pairs
+    deniedConnections:
+      - nodeName: "node2"
+        rules:
+          - "000000000002:*"
+      - nodeName: "node3"
+        rules:
+          - "*:*"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -163,7 +163,7 @@ source $SCRIPTDIR/common.bash
 
 header
 log separator
-verify_min_k8s_version "1" "20"
+verify_min_k8s_version "1" "18"
 verify_max_k8s_version "1" "24"
 verify_snap_crds
 verify_snapshot_controller

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -163,7 +163,7 @@ source $SCRIPTDIR/common.bash
 
 header
 log separator
-verify_min_k8s_version "1" "18"
+verify_min_k8s_version "1" "20"
 verify_max_k8s_version "1" "24"
 verify_snap_crds
 verify_snapshot_controller


### PR DESCRIPTION
Code changes to support 1.24 k8s version for PowerMax
Created sample/json file for k8 1.24

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/298 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken


![image](https://user-images.githubusercontent.com/92081029/168829620-9591a2a5-1ad0-4a9a-bc6a-e9bc22e9e6f0.png)

![Operator_install_24](https://user-images.githubusercontent.com/92081029/168829650-061b065b-82ff-44e1-83dc-7d37757043b6.png)

![driver_install_k8_24](https://user-images.githubusercontent.com/92081029/168829701-3faa8ce0-dff0-4717-b253-456121590ec3.png)

