### PR TITLE
Update-default-path-limit

### DIFF
--- a/samples/isilon_v230_k8s_121.yaml
+++ b/samples/isilon_v230_k8s_121.yaml
@@ -86,10 +86,10 @@ spec:
           value: "false"
 
         # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
-        # Default value: 128
-        # Examples: 128, 256
+        # Default value: 192
+        # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
-          value: "128"
+          value: "192"
 
     controller:
       envs:

--- a/samples/isilon_v230_k8s_122.yaml
+++ b/samples/isilon_v230_k8s_122.yaml
@@ -86,10 +86,10 @@ spec:
           value: "false"
 
         # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
-        # Default value: 128
-        # Examples: 128, 256
+        # Default value: 192
+        # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
-          value: "128"
+          value: "192"
 
     controller:
       envs:

--- a/samples/isilon_v230_k8s_123.yaml
+++ b/samples/isilon_v230_k8s_123.yaml
@@ -86,10 +86,10 @@ spec:
           value: "false"
 
         # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
-        # Default value: 128
-        # Examples: 128, 256
+        # Default value: 192
+        # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
-          value: "128"
+          value: "192"
 
     controller:
       envs:

--- a/samples/isilon_v230_k8s_124.yaml
+++ b/samples/isilon_v230_k8s_124.yaml
@@ -86,10 +86,10 @@ spec:
           value: "false"
 
         # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
-        # Default value: 128
-        # Examples: 128, 256
+        # Default value: 192
+        # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
-          value: "128"
+          value: "192"
 
     controller:
       envs:

--- a/samples/isilon_v230_ops_410.yaml
+++ b/samples/isilon_v230_ops_410.yaml
@@ -86,10 +86,10 @@ spec:
           value: "false"
 
         # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
-        # Default value: 128
-        # Examples: 128, 256
+        # Default value: 192
+        # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
-          value: "128"
+          value: "192"
 
     controller:
       envs:

--- a/samples/isilon_v230_ops_49.yaml
+++ b/samples/isilon_v230_ops_49.yaml
@@ -86,10 +86,10 @@ spec:
           value: "false"
 
         # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
-        # Default value: 128
-        # Examples: 128, 256
+        # Default value: 192
+        # Examples: 192, 256
         - name: X_CSI_MAX_PATH_LIMIT
-          value: "128"
+          value: "192"
 
     controller:
       envs:


### PR DESCRIPTION
# Description
Update default path value to 192 from 128, as the default was changed to support k8s 1.24

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/263

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
