### PR TITLE
Update manifests, remove references of old K8s versions

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -412,10 +412,7 @@ const (
 	Error          CSIOperatorConditionType = "Error"
 	Updating       CSIOperatorConditionType = "Updating"
 	Failed         CSIOperatorConditionType = "Failed"
-	k8sv117        K8sVersion               = "v117"
-	k8sv118        K8sVersion               = "v118"
-	k8sv119        K8sVersion               = "v119"
-	BaseK8sVersion K8sVersion               = "v117"
+	BaseK8sVersion K8sVersion               = "v121"
 )
 
 // SideCarType - type representing type of the sidecar container

--- a/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
@@ -46,6 +46,10 @@ metadata:
                   {
                     "name": "X_CSI_CUSTOM_TOPOLOGY_ENABLED",
                     "value": "false"
+                  },
+                  {
+                    "name": "X_CSI_MAX_PATH_LIMIT",
+                    "value": "192"
                   }
                 ],
                 "image": "dellemc/csi-isilon:v2.3.0",
@@ -262,8 +266,16 @@ metadata:
                 "imagePullPolicy": "IfNotPresent"
               },
               "configVersion": "v2.3.0",
+              "controller": {
+                "nodeSelector": null,
+                "tolerations": null
+              },
               "dnsPolicy": "ClusterFirstWithHostNet",
               "forceUpdate": false,
+              "node": {
+                "nodeSelector": null,
+                "tolerations": null
+              },
               "replicas": 2,
               "sideCars": [
                 {
@@ -311,12 +323,13 @@ metadata:
                     "value": "false"
                   }
                 ],
-                "image": "dellemc/csi-vxflexos:v2.2.0",
+                "image": "dellemc/csi-vxflexos:v2.3.0",
                 "imagePullPolicy": "IfNotPresent"
               },
-              "configVersion": "v2.2.0",
+              "configVersion": "v2.3.0",
               "dnsPolicy": "ClusterFirstWithHostNet",
               "forceUpdate": false,
+              "fsGroupPolicy": "File",
               "initContainers": [
                 {
                   "envs": [

--- a/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
+++ b/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
@@ -46,6 +46,10 @@ metadata:
                   {
                     "name": "X_CSI_CUSTOM_TOPOLOGY_ENABLED",
                     "value": "false"
+                  },
+                  {
+                    "name": "X_CSI_MAX_PATH_LIMIT",
+                    "value": "192"
                   }
                 ],
                 "image": "dellemc/csi-isilon:v2.3.0",
@@ -262,8 +266,16 @@ metadata:
                 "imagePullPolicy": "IfNotPresent"
               },
               "configVersion": "v2.3.0",
+              "controller": {
+                "nodeSelector": null,
+                "tolerations": null
+              },
               "dnsPolicy": "ClusterFirstWithHostNet",
               "forceUpdate": false,
+              "node": {
+                "nodeSelector": null,
+                "tolerations": null
+              },
               "replicas": 2,
               "sideCars": [
                 {

--- a/config/samples/storage_v1_csiisilon.yaml
+++ b/config/samples/storage_v1_csiisilon.yaml
@@ -85,6 +85,12 @@ spec:
         - name: X_CSI_CUSTOM_TOPOLOGY_ENABLED
           value: "false"
 
+        # X_CSI_MAX_PATH_LIMIT: this parameter is used for setting the maximum Path length for the given volume.
+        # Default value: 192
+        # Examples: 192, 256
+        - name: X_CSI_MAX_PATH_LIMIT
+          value: "192"
+
     controller:
       envs:
       # X_CSI_ISI_QUOTA_ENABLED: Indicates whether the provisioner should attempt to set (later unset) quota

--- a/config/samples/storage_v1_csipowerstore.yaml
+++ b/config/samples/storage_v1_csipowerstore.yaml
@@ -58,7 +58,7 @@ spec:
       tolerations:
       #  - key: "node-role.kubernetes.io/control-plane"
       #    operator: "Exists"
-      #    effect: "NoSchedule"      
+      #    effect: "NoSchedule"         
     node:
       envs:
         # Set to "true" to enable ISCSI CHAP Authentication
@@ -83,4 +83,4 @@ spec:
       tolerations:
       #  - key: "node-role.kubernetes.io/worker"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoSchedule"    

--- a/config/samples/storage_v1_csiunity.yaml
+++ b/config/samples/storage_v1_csiunity.yaml
@@ -17,3 +17,47 @@ spec:
         args: ["--volume-name-prefix=csiunity","--default-fstype=ext4"]
       - name: snapshotter
         args: ["--snapshot-name-prefix=csiunitysnap"]
+    controller:
+      # nodeSelector: Define node selection constraints for controller pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      # Examples:
+      #   node-role.kubernetes.io/control-plane: ""
+      nodeSelector:
+      #   node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the controllers, if required.
+      # Leave as blank to install controller on worker nodes
+      # Default value: None
+      tolerations:
+      #  - key: "node-role.kubernetes.io/control-plane"
+      #    operator: "Exists"
+      #    effect: "NoSchedule"
+
+    node:
+      # nodeSelector: Define node selection constraints for node pods.
+      # For the pod to be eligible to run on a node, the node must have each
+      # of the indicated key-value pairs as labels.
+      # Leave as blank to consider all nodes
+      # Allowed values: map of key-value pairs
+      # Default value: None
+      # Examples:
+      #   node-role.kubernetes.io/control-plane: ""
+      nodeSelector:
+      #   node-role.kubernetes.io/control-plane: ""
+
+      # tolerations: Define tolerations for the node daemonset, if required.
+      # Default value: None
+      tolerations:
+      #  - key: "node.kubernetes.io/memory-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"

--- a/config/samples/storage_v1_csivxflexos.yaml
+++ b/config/samples/storage_v1_csivxflexos.yaml
@@ -9,7 +9,7 @@ spec:
     replicas: 1
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
-    fsGroupPolicy: File 
+    fsGroupPolicy: File
     common:
       image: "dellemc/csi-vxflexos:v2.3.0"
       imagePullPolicy: IfNotPresent

--- a/documentation/Readme.md
+++ b/documentation/Readme.md
@@ -33,7 +33,7 @@ For any CSI operator and driver issues, questions or feedback, join the [Dell EM
 Dell CSI Operator has been tested and qualified with 
 
     * Upstream Kubernetes cluster v1.22, v1.23, v1.24
-    * OpenShift Clusters 4.9, 4.10 with RHEL 7.x & RHCOS worker nodes
+    * OpenShift Clusters 4.9, 4.10 with RHEL 7.x (with OCP 4.9), RHEL 8.x (with OCP 4.10) & RHCOS worker nodes
 
 ## Installation
 To install Dell CSI Operator please refer the steps given here at [https://dell.github.io/csm-docs/docs/csidriver/installation/operator/](https://dell.github.io/csm-docs/docs/csidriver/installation/operator/)

--- a/driverconfig/config.yaml
+++ b/driverconfig/config.yaml
@@ -1,7 +1,4 @@
 supportedK8sVersions:
-  - v117
-  - v118
-  - v119
   - v120
   - v121
   - v122
@@ -169,12 +166,6 @@ drivers:
 csiSideCars:
   - name: attacher
     images:
-      - version: v117
-        tag: k8s.gcr.io/sig-storage/csi-attacher:v3.0.0
-      - version: v118
-        tag: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
-      - version: v119
-        tag: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
       - version: v120
         tag: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
       - version: v121
@@ -187,12 +178,6 @@ csiSideCars:
         tag: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
   - name: provisioner
     images:
-      - version: v117
-        tag: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2
-      - version: v118
-        tag: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
-      - version: v119
-        tag: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
       - version: v120
         tag: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
       - version: v121
@@ -205,12 +190,6 @@ csiSideCars:
         tag: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
   - name: snapshotter
     images:
-      - version: v117
-        tag: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.2
-      - version: v118
-        tag: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
-      - version: v119
-        tag: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
       - version: v120
         tag: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
       - version: v121
@@ -223,12 +202,6 @@ csiSideCars:
         tag: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
   - name: resizer
     images:
-      - version: v117
-        tag: quay.io/k8scsi/csi-resizer:v1.0.0
-      - version: v118
-        tag: quay.io/k8scsi/csi-resizer:v1.1.0
-      - version: v119
-        tag: quay.io/k8scsi/csi-resizer:v1.1.0
       - version: v120
         tag: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
       - version: v121
@@ -241,12 +214,6 @@ csiSideCars:
         tag: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
   - name: registrar
     images:
-      - version: v117
-        tag: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
-      - version: v118
-        tag: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
-      - version: v119
-        tag: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
       - version: v120
         tag: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
       - version: v121
@@ -260,12 +227,6 @@ csiSideCars:
 extensions:
   - name: sdc-monitor
     images:
-      - version: v117
-        tag: dellemc/sdc:3.5.1.1
-      - version: v118
-        tag: dellemc/sdc:3.5.1.1-1
-      - version: v119
-        tag: dellemc/sdc:3.6
       - version: v120
         tag: dellemc/sdc:3.6
       - version: v121
@@ -278,12 +239,6 @@ extensions:
         tag: dellemc/sdc:3.6
   - name: sdc
     images:
-      - version: v117
-        tag: dellemc/sdc:3.5.1.1
-      - version: v118
-        tag: dellemc/sdc:3.5.1.1-1
-      - version: v119
-        tag: dellemc/sdc:3.6
       - version: v120
         tag: dellemc/sdc:3.6
       - version: v121

--- a/driverconfig/unity_v230_v124.json
+++ b/driverconfig/unity_v230_v124.json
@@ -1,457 +1,457 @@
 {
-    "driverConfig": {
-      "controllerHA": true,
-      "enableEphemeralVolumes": true,
-      "driverEnvs": [
-        {
-          "Name": "CSI_ENDPOINT",
-          "CSIEnvType": "String",
-          "SetForController": true,
-          "SetForNode": true,
-          "DefaultValueForController": "/var/run/csi/csi.sock",
-          "DefaultValueForNode": "unix:///var/lib/kubelet/plugins/unity.emc.dell.com/csi_sock"
-        },
-        {
-          "Name": "X_CSI_MODE",
-          "CSIEnvType": "String",
-          "SetForController": true,
-          "SetForNode": true,
-          "DefaultValueForController": "controller",
-          "DefaultValueForNode": "node"
-        },
-        {
-          "Name": "X_CSI_UNITY_AUTOPROBE",
+  "driverConfig": {
+    "controllerHA": true,
+    "enableEphemeralVolumes": true,
+    "driverEnvs": [
+      {
+        "Name": "CSI_ENDPOINT",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "/var/run/csi/csi.sock",
+        "DefaultValueForNode": "unix:///var/lib/kubelet/plugins/unity.emc.dell.com/csi_sock"
+      },
+      {
+        "Name": "X_CSI_MODE",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "controller",
+        "DefaultValueForNode": "node"
+      },
+      {
+        "Name": "X_CSI_UNITY_AUTOPROBE",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "true",
+        "DefaultValueForNode": "true"
+      },
+      {
+        "Name": "X_CSI_PRIVATE_MOUNT_DIR",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/var/lib/kubelet/plugins/unity.emc.dell.com/disks"
+      },
+      {
+        "Name": "X_CSI_EPHEMERAL_STAGING_PATH",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+      },
+      {
+        "Name": "X_CSI_ISCSI_CHROOT",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "/noderoot"
+      },
+      {
+        "Name": "X_CSI_UNITY_NODENAME",
+        "CSIEnvType": "EnvVarReferenceType",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "v1/spec.nodeName"
+      },
+      {
+        "Name": "X_CSI_UNITY_NODENAME_PREFIX",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "csi-node"
+      },
+      {
+        "Name": "SSL_CERT_DIR",
+        "CSIEnvType": "String",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "/certs",
+        "DefaultValueForNode": "/certs"
+      },
+      {
+        "Name": "X_CSI_UNITY_SYNC_NODEINFO_INTERVAL",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "15"
+      },
+      {
+          "Name": "X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS",
           "CSIEnvType": "Boolean",
-          "SetForController": true,
-          "SetForNode": true,
-          "DefaultValueForController": "true",
-          "DefaultValueForNode": "true"
-        },
-        {
-          "Name": "X_CSI_PRIVATE_MOUNT_DIR",
-          "CSIEnvType": "String",
           "SetForController": false,
-          "SetForNode": true,
-          "DefaultValueForController": "",
-          "DefaultValueForNode": "/var/lib/kubelet/plugins/unity.emc.dell.com/disks"
-        },
-        {
-          "Name": "X_CSI_EPHEMERAL_STAGING_PATH",
-          "CSIEnvType": "String",
-          "SetForController": false,
-          "SetForNode": true,
-          "DefaultValueForController": "",
-          "DefaultValueForNode": "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
-        },
-        {
-          "Name": "X_CSI_ISCSI_CHROOT",
-          "CSIEnvType": "String",
-          "SetForController": false,
-          "SetForNode": true,
-          "DefaultValueForController": "",
-          "DefaultValueForNode": "/noderoot"
-        },
-        {
-          "Name": "X_CSI_UNITY_NODENAME",
-          "CSIEnvType": "EnvVarReferenceType",
-          "SetForController": false,
-          "SetForNode": true,
-          "DefaultValueForController": "",
-          "DefaultValueForNode": "v1/spec.nodeName"
-        },
-        {
-          "Name": "X_CSI_UNITY_NODENAME_PREFIX",
-          "CSIEnvType": "String",
-          "SetForController": false,
-          "SetForNode": true,
-          "DefaultValueForController": "",
-          "DefaultValueForNode": "csi-node"
-        },
-        {
-          "Name": "SSL_CERT_DIR",
-          "CSIEnvType": "String",
-          "SetForController": true,
-          "SetForNode": true,
-          "DefaultValueForController": "/certs",
-          "DefaultValueForNode": "/certs"
-        },
-        {
-          "Name": "X_CSI_UNITY_SYNC_NODEINFO_INTERVAL",
-          "CSIEnvType": "String",
-          "SetForController": false,
-          "SetForNode": true,
-          "DefaultValueForController": "",
-          "DefaultValueForNode": "15"
-        },
-        {
-            "Name": "X_CSI_UNITY_ALLOW_MULTI_POD_ACCESS",
-            "CSIEnvType": "Boolean",
-            "SetForController": false,
-            "SetForNode": true,
-            "DefaultValueForController": "false",
-            "DefaultValueForNode": "false"
-        },
-        {
-          "Name": "X_CSI_MAX_VOLUMES_PER_NODE",
-          "CSIEnvType": "String",
-          "SetForController": false,
-          "SetForNode": true,
-          "DefaultValueForController": "",
-          "DefaultValueForNode": "0"
-        },
-        {
-          "Name": "X_CSI_HEALTH_MONITOR_ENABLED",
-          "CSIEnvType": "Boolean",
-          "SetForController": true,
           "SetForNode": true,
           "DefaultValueForController": "false",
           "DefaultValueForNode": "false"
+      },
+      {
+        "Name": "X_CSI_MAX_VOLUMES_PER_NODE",
+        "CSIEnvType": "String",
+        "SetForController": false,
+        "SetForNode": true,
+        "DefaultValueForController": "",
+        "DefaultValueForNode": "0"
+      },
+      {
+        "Name": "X_CSI_HEALTH_MONITOR_ENABLED",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": true,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": "false"
+      }
+    ],
+    "driverArgs": [
+      "--driver-name=csi-unity.dellemc.com",
+      "--driver-config=/unity-config/driver-config-params.yaml",
+      "--driver-secret=/unity-secret/config"
+    ],
+    "driverNodeVolumes": [
+      {
+        "hostPath": {
+          "path": "/var/lib/kubelet/plugins_registry/",
+          "type": "DirectoryOrCreate"
+        },
+        "name": "registration-dir"
+      },
+      {
+        "hostPath": {
+          "path": "/var/lib/kubelet/plugins/unity.emc.dell.com",
+          "type": "DirectoryOrCreate"
+        },
+        "name": "driver-path"
+      },
+      {
+        "hostPath": {
+          "path": "/var/lib/kubelet/plugins/kubernetes.io/csi",
+          "type": "DirectoryOrCreate"
+        },
+        "name": "volumedevices-path"
+      },
+      {
+        "hostPath": {
+          "path": "/var/lib/kubelet/pods",
+          "type": "Directory"
+        },
+        "name": "pods-path"
+      },
+      {
+        "hostPath": {
+          "path": "/dev",
+          "type": "Directory"
+        },
+        "name": "dev"
+      },
+      {
+        "hostPath": {
+          "path": "/",
+          "type": "Directory"
+        },
+        "name": "noderoot"
+      },
+      {
+        "name": "unity-config",
+        "configMap": {
+          "defaultMode": 420,
+          "name": "unity-config-params",
+          "optional": true
         }
-      ],
-      "driverArgs": [
-        "--driver-name=csi-unity.dellemc.com",
-        "--driver-config=/unity-config/driver-config-params.yaml",
-        "--driver-secret=/unity-secret/config"
-      ],
-      "driverNodeVolumes": [
-        {
-          "hostPath": {
-            "path": "/var/lib/kubelet/plugins_registry/",
-            "type": "DirectoryOrCreate"
-          },
-          "name": "registration-dir"
-        },
-        {
-          "hostPath": {
-            "path": "/var/lib/kubelet/plugins/unity.emc.dell.com",
-            "type": "DirectoryOrCreate"
-          },
-          "name": "driver-path"
-        },
-        {
-          "hostPath": {
-            "path": "/var/lib/kubelet/plugins/kubernetes.io/csi",
-            "type": "DirectoryOrCreate"
-          },
-          "name": "volumedevices-path"
-        },
-        {
-          "hostPath": {
-            "path": "/var/lib/kubelet/pods",
-            "type": "Directory"
-          },
-          "name": "pods-path"
-        },
-        {
-          "hostPath": {
-            "path": "/dev",
-            "type": "Directory"
-          },
-          "name": "dev"
-        },
-        {
-          "hostPath": {
-            "path": "/",
-            "type": "Directory"
-          },
-          "name": "noderoot"
-        },
-        {
-          "name": "unity-config",
-          "configMap": {
-            "defaultMode": 420,
-            "name": "unity-config-params",
-            "optional": true
-          }
-        },
-        {
-          "name": "unity-secret",
-          "secret": {
-            "defaultMode": 420,
-            "secretName": "unity-creds",
-            "optional": true
-          }
+      },
+      {
+        "name": "unity-secret",
+        "secret": {
+          "defaultMode": 420,
+          "secretName": "unity-creds",
+          "optional": true
         }
-      ],
-      "driverControllerVolumes": [
-        {
-          "emptyDir": {},
-          "name": "socket-dir"
-        },
-        {
-          "name": "certs",
-          "secret": {
-            "defaultMode": 420,
-            "secretName": "unity-certs",
-            "optional": true
-          }
-        },
-        {
-          "name": "unity-config",
-          "configMap": {
-            "defaultMode": 420,
-            "name": "unity-config-params",
-            "optional": true
-          }
-        },
-        {
-          "name": "unity-secret",
-          "secret": {
-            "defaultMode": 420,
-            "secretName": "unity-creds",
-            "optional": true
-          }
+      }
+    ],
+    "driverControllerVolumes": [
+      {
+        "emptyDir": {},
+        "name": "socket-dir"
+      },
+      {
+        "name": "certs",
+        "secret": {
+          "defaultMode": 420,
+          "secretName": "unity-certs",
+          "optional": true
         }
-      ],
-      "driverControllerVolumeMounts": [
-        {
-          "mountPath": "/var/run/csi",
-          "name": "socket-dir"
-        },
-        {
-          "mountPath": "/certs",
-          "name": "certs",
-          "readOnly": true
-        },
-        {
-          "mountPath": "/unity-config",
-          "name": "unity-config",
-          "readOnly": true
-        },
-        {
-          "mountPath": "/unity-secret",
-          "name": "unity-secret",
-          "readOnly": true
+      },
+      {
+        "name": "unity-config",
+        "configMap": {
+          "defaultMode": 420,
+          "name": "unity-config-params",
+          "optional": true
         }
-      ],
-      "driverNodeVolumeMounts": [
-        {
-          "mountPath": "/var/lib/kubelet/plugins/unity.emc.dell.com",
-          "name": "driver-path"
-        },
-        {
-          "mountPath": "/var/lib/kubelet/plugins/kubernetes.io/csi",
-          "mountPropagation": "Bidirectional",
-          "name": "volumedevices-path"
-        },
-        {
-          "mountPath": "/var/lib/kubelet/pods",
-          "mountPropagation": "Bidirectional",
-          "name": "pods-path"
-        },
-        {
-          "mountPath": "/dev",
-          "name": "dev"
-        },
-        {
-          "mountPath": "/noderoot",
-          "name": "noderoot"
-        },
-        {
-          "mountPath": "/certs",
-          "name": "certs",
-          "readOnly": true
-        },
-        {
-          "mountPath": "/unity-config",
-          "name": "unity-config",
-          "readOnly": true
-        },
-        {
-          "mountPath": "/unity-secret",
-          "name": "unity-secret",
-          "readOnly": true
+      },
+      {
+        "name": "unity-secret",
+        "secret": {
+          "defaultMode": 420,
+          "secretName": "unity-creds",
+          "optional": true
         }
-      ],
-      "sidecarParams": [
-        {
-          "name": "provisioner",
-          "args": [
-            "--csi-address=$(ADDRESS)",
-            "--timeout=120s",
-            "--volume-name-uuid-length=10",
-            "--timeout=180s",
-            "--worker-threads=6",
-            "--v=5",
-            "--volume-name-prefix=csiunity",
-            "--leader-election",
-            "--default-fstype=ext4"
-          ],
-          "envs": [
-            {
-              "name": "ADDRESS",
-              "value": "/var/run/csi/csi.sock"
-            }
-          ],
-          "volumeMounts": [
-            {
-              "mountPath": "/var/run/csi",
-              "name": "socket-dir"
-            }
-          ]
-        },
-        {
-          "name": "attacher",
-          "args": [
-            "--csi-address=$(ADDRESS)",
-            "--v=5",
-            "--timeout=180s",
-            "--leader-election"
-          ],
-          "envs": [
-            {
-              "name": "ADDRESS",
-              "value": "/var/run/csi/csi.sock"
-            }
-          ],
-          "volumeMounts": [
-            {
-              "mountPath": "/var/run/csi",
-              "name": "socket-dir"
-            }
-          ]
-        },
-        {
-          "name": "snapshotter",
-          "args": [
-            "--v=5",
-            "--snapshot-name-uuid-length=10",
-            "--timeout=360s",
-            "--csi-address=$(ADDRESS)",
-            "--snapshot-name-prefix=csi-snap",
-            "--leader-election"
-          ],
-          "envs": [
-            {
-              "name": "ADDRESS",
-              "value": "/var/run/csi/csi.sock"
-            }
-          ],
-          "volumeMounts": [
-            {
-              "mountPath": "/var/run/csi",
-              "name": "socket-dir"
-            }
-          ]
-        },
-        {
-          "name": "external-health-monitor",
-          "optional": true,
-          "args": [
-            "--csi-address=$(ADDRESS)",
-            "--timeout=180s",
-            "--v=5",
-            "--leader-election",
-            "--monitor-interval=60s",
-            "--enable-node-watcher=true",
-            "--http-endpoint=:8080"
-          ],
-          "envs": [
-            {
-              "name": "ADDRESS",
-              "value": "/var/run/csi/csi.sock"
-            }
-          ],
-          "volumeMounts": [
-            {
-              "mountPath": "/var/run/csi",
-              "name": "socket-dir"
-            }
-          ]
-        },
-        {
-          "name": "registrar",
-          "args": [
-            "--v=5",
-            "--csi-address=$(ADDRESS)",
-            "--kubelet-registration-path=/var/lib/kubelet/plugins/unity.emc.dell.com/csi_sock"
-          ],
-          "envs": [
-            {
-              "name": "ADDRESS",
-              "value": "/csi/csi_sock"
-            },
-            {
-              "name": "KUBE_NODE_NAME",
-              "valueFrom": {
-                "fieldRef": {
-                  "apiVersion": "v1",
-                  "fieldPath": "spec.nodeName"
-                }
+      }
+    ],
+    "driverControllerVolumeMounts": [
+      {
+        "mountPath": "/var/run/csi",
+        "name": "socket-dir"
+      },
+      {
+        "mountPath": "/certs",
+        "name": "certs",
+        "readOnly": true
+      },
+      {
+        "mountPath": "/unity-config",
+        "name": "unity-config",
+        "readOnly": true
+      },
+      {
+        "mountPath": "/unity-secret",
+        "name": "unity-secret",
+        "readOnly": true
+      }
+    ],
+    "driverNodeVolumeMounts": [
+      {
+        "mountPath": "/var/lib/kubelet/plugins/unity.emc.dell.com",
+        "name": "driver-path"
+      },
+      {
+        "mountPath": "/var/lib/kubelet/plugins/kubernetes.io/csi",
+        "mountPropagation": "Bidirectional",
+        "name": "volumedevices-path"
+      },
+      {
+        "mountPath": "/var/lib/kubelet/pods",
+        "mountPropagation": "Bidirectional",
+        "name": "pods-path"
+      },
+      {
+        "mountPath": "/dev",
+        "name": "dev"
+      },
+      {
+        "mountPath": "/noderoot",
+        "name": "noderoot"
+      },
+      {
+        "mountPath": "/certs",
+        "name": "certs",
+        "readOnly": true
+      },
+      {
+        "mountPath": "/unity-config",
+        "name": "unity-config",
+        "readOnly": true
+      },
+      {
+        "mountPath": "/unity-secret",
+        "name": "unity-secret",
+        "readOnly": true
+      }
+    ],
+    "sidecarParams": [
+      {
+        "name": "provisioner",
+        "args": [
+          "--csi-address=$(ADDRESS)",
+          "--timeout=120s",
+          "--volume-name-uuid-length=10",
+          "--timeout=180s",
+          "--worker-threads=6",
+          "--v=5",
+          "--volume-name-prefix=csiunity",
+          "--leader-election",
+          "--default-fstype=ext4"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      },
+      {
+        "name": "attacher",
+        "args": [
+          "--csi-address=$(ADDRESS)",
+          "--v=5",
+          "--timeout=180s",
+          "--leader-election"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      },
+      {
+        "name": "snapshotter",
+        "args": [
+          "--v=5",
+          "--snapshot-name-uuid-length=10",
+          "--timeout=360s",
+          "--csi-address=$(ADDRESS)",
+          "--snapshot-name-prefix=csi-snap",
+          "--leader-election"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      },
+      {
+        "name": "external-health-monitor",
+        "optional": true,
+        "args": [
+          "--csi-address=$(ADDRESS)",
+          "--timeout=180s",
+          "--v=5",
+          "--leader-election",
+          "--monitor-interval=60s",
+          "--enable-node-watcher=true",
+          "--http-endpoint=:8080"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      },
+      {
+        "name": "registrar",
+        "args": [
+          "--v=5",
+          "--csi-address=$(ADDRESS)",
+          "--kubelet-registration-path=/var/lib/kubelet/plugins/unity.emc.dell.com/csi_sock"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/csi/csi_sock"
+          },
+          {
+            "name": "KUBE_NODE_NAME",
+            "valueFrom": {
+              "fieldRef": {
+                "apiVersion": "v1",
+                "fieldPath": "spec.nodeName"
               }
             }
-          ],
-          "volumeMounts": [
-            {
-              "mountPath": "/registration",
-              "name": "registration-dir"
-            },
-            {
-              "mountPath": "/csi",
-              "name": "driver-path"
-            }
-          ]
-        },
-        {
-          "name": "resizer",
-          "args": [
-            "--csi-address=$(ADDRESS)",
-            "--v=5",
-            "--leader-election"
-          ],
-          "envs": [
-            {
-              "name": "ADDRESS",
-              "value": "/var/run/csi/csi.sock"
-            }
-          ],
-          "volumeMounts": [
-            {
-              "mountPath": "/var/run/csi",
-              "name": "socket-dir"
-            }
-          ]
-        }
-      ],
-      "storageClassParams": [
-        {
-          "Name": "storagePool",
-          "Mandatory": true
-        },
-        {
-          "Name": "arrayId",
-          "Mandatory": true
-        },
-        {
-          "Name": "FsType",
-          "Mandatory": false
-        },
-        {
-          "Name": "thinProvisioned"
-        },
-        {
-          "Name": "isDataReductionEnabled"
-        },
-        {
-          "Name": "tieringPolicy"
-        },
-        {
-          "Name": "hostIOLimitName"
-        },
-        {
-          "Name": "hostIoSize",
-          "Mandatory": false
-        }
-      ],
-      "storageClassAttrs": [
-        {
-          "name": "allowVolumeExpansion",
-          "value": true
-        },
-        {
-          "name": "volumeBindingMode",
-          "value": "Immediate"
-        }
-      ]
-    }
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/registration",
+            "name": "registration-dir"
+          },
+          {
+            "mountPath": "/csi",
+            "name": "driver-path"
+          }
+        ]
+      },
+      {
+        "name": "resizer",
+        "args": [
+          "--csi-address=$(ADDRESS)",
+          "--v=5",
+          "--leader-election"
+        ],
+        "envs": [
+          {
+            "name": "ADDRESS",
+            "value": "/var/run/csi/csi.sock"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/csi",
+            "name": "socket-dir"
+          }
+        ]
+      }
+    ],
+    "storageClassParams": [
+      {
+        "Name": "storagePool",
+        "Mandatory": true
+      },
+      {
+        "Name": "arrayId",
+        "Mandatory": true
+      },
+      {
+        "Name": "FsType",
+        "Mandatory": false
+      },
+      {
+        "Name": "thinProvisioned"
+      },
+      {
+        "Name": "isDataReductionEnabled"
+      },
+      {
+        "Name": "tieringPolicy"
+      },
+      {
+        "Name": "hostIOLimitName"
+      },
+      {
+        "Name": "hostIoSize",
+        "Mandatory": false
+      }
+    ],
+    "storageClassAttrs": [
+      {
+        "name": "allowVolumeExpansion",
+        "value": true
+      },
+      {
+        "name": "volumeBindingMode",
+        "value": "Immediate"
+      }
+    ]
   }
+}

--- a/samples/unity_v220_k8s_121.yaml
+++ b/samples/unity_v220_k8s_121.yaml
@@ -72,13 +72,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1

--- a/samples/unity_v220_k8s_122.yaml
+++ b/samples/unity_v220_k8s_122.yaml
@@ -71,13 +71,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1

--- a/samples/unity_v220_k8s_123.yaml
+++ b/samples/unity_v220_k8s_123.yaml
@@ -71,13 +71,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1

--- a/samples/unity_v220_ops_48.yaml
+++ b/samples/unity_v220_ops_48.yaml
@@ -49,13 +49,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1

--- a/samples/unity_v220_ops_49.yaml
+++ b/samples/unity_v220_ops_49.yaml
@@ -49,13 +49,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1

--- a/samples/unity_v230_k8s_121.yaml
+++ b/samples/unity_v230_k8s_121.yaml
@@ -72,13 +72,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1

--- a/samples/unity_v230_k8s_122.yaml
+++ b/samples/unity_v230_k8s_122.yaml
@@ -71,13 +71,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1
@@ -92,4 +97,3 @@ data:
     MAX_UNITY_VOLUMES_PER_NODE: "0"
     SYNC_NODE_INFO_TIME_INTERVAL: "15"
     TENANT_NAME: ""
-

--- a/samples/unity_v230_k8s_123.yaml
+++ b/samples/unity_v230_k8s_123.yaml
@@ -71,13 +71,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1
@@ -92,4 +97,3 @@ data:
     MAX_UNITY_VOLUMES_PER_NODE: "0"
     SYNC_NODE_INFO_TIME_INTERVAL: "15"
     TENANT_NAME: ""
-

--- a/samples/unity_v230_k8s_124.yaml
+++ b/samples/unity_v230_k8s_124.yaml
@@ -71,13 +71,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1
@@ -92,4 +97,3 @@ data:
     MAX_UNITY_VOLUMES_PER_NODE: "0"
     SYNC_NODE_INFO_TIME_INTERVAL: "15"
     TENANT_NAME: ""
-

--- a/samples/unity_v230_ops_410.yaml
+++ b/samples/unity_v230_ops_410.yaml
@@ -49,13 +49,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1

--- a/samples/unity_v230_ops_49.yaml
+++ b/samples/unity_v230_ops_49.yaml
@@ -49,13 +49,18 @@ spec:
       nodeSelector:
       #   node-role.kubernetes.io/control-plane: ""
 
-      # tolerations: Define tolerations for the controllers, if required.
-      # Leave as blank to install controller on worker nodes
+      # tolerations: Define tolerations for the node daemonset, if required.
       # Default value: None
       tolerations:
-      #  - key: "node-role.kubernetes.io/control-plane"
+      #  - key: "node.kubernetes.io/memory-pressure"
       #    operator: "Exists"
-      #    effect: "NoSchedule"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/disk-pressure"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
+      #  - key: "node.kubernetes.io/network-unavailable"
+      #    operator: "Exists"
+      #    effect: "NoExecute"
 
 ---
 apiVersion: v1

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -163,7 +163,7 @@ source $SCRIPTDIR/common.bash
 
 header
 log separator
-verify_min_k8s_version "1" "18"
+verify_min_k8s_version "1" "19"
 verify_max_k8s_version "1" "24"
 verify_snap_crds
 verify_snapshot_controller


### PR DESCRIPTION
# Description
This PR 
- Updates the manifests 
- Updates the support matrix for RHEL worker nodes
- Removes references of older versions of K8s

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/243 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
https://osj-sio-03-prd.cec.lab.emc.com/job/CSI-Operator/job/dell-csi-operator-sanity-k8s-v123/29/console
