### PR TITLE
Correct health monitor sidear version based on driver config version

### DIFF
--- a/driverconfig/config.yaml
+++ b/driverconfig/config.yaml
@@ -230,6 +230,18 @@ csiSideCars:
         tag: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
       - version: v124
         tag: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+  - name: external-health-monitor
+    images:
+      - version: v120
+        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.4.0
+      - version: v121
+        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
+      - version: v122
+        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
+      - version: v123
+        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
+      - version: v124
+        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
 extensions:
   - name: sdc-monitor
     images:
@@ -255,16 +267,4 @@ extensions:
         tag: dellemc/sdc:3.6
       - version: v124
         tag: dellemc/sdc:3.6
-  - name: external-health-monitor
-    images:
-      - version: v120
-        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.4.0
-      - version: v121
-        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
-      - version: v122
-        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
-      - version: v123
-        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
-      - version: v124
-        tag: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
 

--- a/pkg/ctrlconfig/opconfig.go
+++ b/pkg/ctrlconfig/opconfig.go
@@ -34,16 +34,18 @@ type ConfigVersionParams struct {
 	Resizer           string                   `yaml:"resizer,omitempty"`
 	Snapshotter       string                   `yaml:"snapshotter,omitempty"`
 	Registrar         string                   `yaml:"registrar,omitempty"`
+	Healthmonitor     string                   `yaml:"external-health-monitor,omitempty"`
 }
 
 // SupportedVersionParams - Represents the supported versions and corresponding sidecars
 type SupportedVersionParams struct {
-	Version     csiv1.K8sVersion `yaml:"version"`
-	Attacher    string           `yaml:"attacher,omitempty"`
-	Provisioner string           `yaml:"provisioner,omitempty"`
-	Resizer     string           `yaml:"resizer,omitempty"`
-	Snapshotter string           `yaml:"snapshotter,omitempty"`
-	Registrar   string           `yaml:"registrar,omitempty"`
+	Version       csiv1.K8sVersion `yaml:"version"`
+	Attacher      string           `yaml:"attacher,omitempty"`
+	Provisioner   string           `yaml:"provisioner,omitempty"`
+	Resizer       string           `yaml:"resizer,omitempty"`
+	Snapshotter   string           `yaml:"snapshotter,omitempty"`
+	Registrar     string           `yaml:"registrar,omitempty"`
+	Healthmonitor string           `yaml:"external-health-monitor,omitempty"`
 }
 
 // ImageTag - Image tag with associated K8s version
@@ -152,6 +154,7 @@ func (opConfig *OpConfig) GetDefaultImageTags(driverType csiv1.DriverType, confi
 						imageMap[csiv1.Resizer] = configVersionParams.Resizer
 						imageMap[csiv1.Snapshotter] = configVersionParams.Snapshotter
 						imageMap[csiv1.Registrar] = configVersionParams.Registrar
+						imageMap[csiv1.Healthmonitor] = configVersionParams.Healthmonitor
 						for _, supportedVersion := range configVersionParams.SupportedVersions {
 							if supportedVersion.Version == k8sVersion {
 								if supportedVersion.Provisioner != "" {
@@ -168,6 +171,9 @@ func (opConfig *OpConfig) GetDefaultImageTags(driverType csiv1.DriverType, confi
 								}
 								if supportedVersion.Registrar != "" {
 									imageMap[csiv1.Registrar] = supportedVersion.Registrar
+								}
+								if supportedVersion.Healthmonitor != "" {
+									imageMap[csiv1.Healthmonitor] = supportedVersion.Healthmonitor
 								}
 							}
 						}


### PR DESCRIPTION
# Description
External health monitor sidecar version downloaded should be based on the driver config version

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/350 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
![image](https://user-images.githubusercontent.com/80810999/181004394-d1762fa8-a04c-4a81-9c20-f212d0d39ada.png)

![image](https://user-images.githubusercontent.com/80810999/181004743-85caad8b-1746-4dce-aa9d-76e641a9aa79.png)
