### PR TITLE
Renaming kubeNodeName environment variable

### DIFF
--- a/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
@@ -235,7 +235,7 @@ metadata:
               "common": {
                 "envs": [
                   {
-                    "name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+                    "name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                     "value": "csi"
                   },
                   {

--- a/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
+++ b/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
@@ -235,7 +235,7 @@ metadata:
               "common": {
                 "envs": [
                   {
-                    "name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+                    "name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                     "value": "csi"
                   },
                   {

--- a/config/samples/storage_v1_csipowerstore.yaml
+++ b/config/samples/storage_v1_csipowerstore.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.4.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/driverconfig/powerstore_v220_v121.json
+++ b/driverconfig/powerstore_v220_v121.json
@@ -28,7 +28,7 @@
           "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODENAME",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "EnvVarReferenceType",
           "SetForController": false,
           "SetForNode": true,
@@ -36,7 +36,7 @@
           "DefaultValueForNode": "v1/spec.nodeName"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "String",
           "SetForController": false,
           "SetForNode": true,

--- a/driverconfig/powerstore_v220_v122.json
+++ b/driverconfig/powerstore_v220_v122.json
@@ -28,7 +28,7 @@
           "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODENAME",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "EnvVarReferenceType",
           "SetForController": false,
           "SetForNode": true,
@@ -36,7 +36,7 @@
           "DefaultValueForNode": "v1/spec.nodeName"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "String",
           "SetForController": false,
           "SetForNode": true,

--- a/driverconfig/powerstore_v220_v123.json
+++ b/driverconfig/powerstore_v220_v123.json
@@ -28,7 +28,7 @@
           "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODENAME",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "EnvVarReferenceType",
           "SetForController": false,
           "SetForNode": true,
@@ -36,7 +36,7 @@
           "DefaultValueForNode": "v1/spec.nodeName"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "String",
           "SetForController": false,
           "SetForNode": true,

--- a/driverconfig/powerstore_v230_v121.json
+++ b/driverconfig/powerstore_v230_v121.json
@@ -27,7 +27,7 @@
                 "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
             },
             {
-                "Name": "X_CSI_POWERSTORE_NODENAME",
+                "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                 "CSIEnvType": "EnvVarReferenceType",
                 "SetForController": false,
                 "SetForNode": true,
@@ -35,7 +35,7 @@
                 "DefaultValueForNode": "v1/spec.nodeName"
             },
             {
-                "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+                "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                 "CSIEnvType": "String",
                 "SetForController": false,
                 "SetForNode": true,

--- a/driverconfig/powerstore_v230_v122.json
+++ b/driverconfig/powerstore_v230_v122.json
@@ -27,7 +27,7 @@
                 "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
             },
             {
-                "Name": "X_CSI_POWERSTORE_NODENAME",
+                "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                 "CSIEnvType": "EnvVarReferenceType",
                 "SetForController": false,
                 "SetForNode": true,
@@ -35,7 +35,7 @@
                 "DefaultValueForNode": "v1/spec.nodeName"
             },
             {
-                "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+                "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                 "CSIEnvType": "String",
                 "SetForController": false,
                 "SetForNode": true,

--- a/driverconfig/powerstore_v230_v123.json
+++ b/driverconfig/powerstore_v230_v123.json
@@ -28,7 +28,7 @@
           "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODENAME",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "EnvVarReferenceType",
           "SetForController": false,
           "SetForNode": true,
@@ -36,7 +36,7 @@
           "DefaultValueForNode": "v1/spec.nodeName"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "String",
           "SetForController": false,
           "SetForNode": true,

--- a/driverconfig/powerstore_v230_v124.json
+++ b/driverconfig/powerstore_v230_v124.json
@@ -28,7 +28,7 @@
           "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODENAME",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "EnvVarReferenceType",
           "SetForController": false,
           "SetForNode": true,
@@ -36,7 +36,7 @@
           "DefaultValueForNode": "v1/spec.nodeName"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "String",
           "SetForController": false,
           "SetForNode": true,

--- a/driverconfig/powerstore_v240_v121.json
+++ b/driverconfig/powerstore_v240_v121.json
@@ -27,7 +27,7 @@
                 "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
             },
             {
-                "Name": "X_CSI_POWERSTORE_NODENAME",
+                "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                 "CSIEnvType": "EnvVarReferenceType",
                 "SetForController": false,
                 "SetForNode": true,
@@ -35,7 +35,7 @@
                 "DefaultValueForNode": "v1/spec.nodeName"
             },
             {
-                "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+                "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                 "CSIEnvType": "String",
                 "SetForController": false,
                 "SetForNode": true,

--- a/driverconfig/powerstore_v240_v122.json
+++ b/driverconfig/powerstore_v240_v122.json
@@ -27,7 +27,7 @@
                 "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
             },
             {
-                "Name": "X_CSI_POWERSTORE_NODENAME",
+                "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                 "CSIEnvType": "EnvVarReferenceType",
                 "SetForController": false,
                 "SetForNode": true,
@@ -35,7 +35,7 @@
                 "DefaultValueForNode": "v1/spec.nodeName"
             },
             {
-                "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+                "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
                 "CSIEnvType": "String",
                 "SetForController": false,
                 "SetForNode": true,

--- a/driverconfig/powerstore_v240_v123.json
+++ b/driverconfig/powerstore_v240_v123.json
@@ -28,7 +28,7 @@
           "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODENAME",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "EnvVarReferenceType",
           "SetForController": false,
           "SetForNode": true,
@@ -36,7 +36,7 @@
           "DefaultValueForNode": "v1/spec.nodeName"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "String",
           "SetForController": false,
           "SetForNode": true,

--- a/driverconfig/powerstore_v240_v124.json
+++ b/driverconfig/powerstore_v240_v124.json
@@ -28,7 +28,7 @@
           "DefaultValueForNode": "/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODENAME",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "EnvVarReferenceType",
           "SetForController": false,
           "SetForNode": true,
@@ -36,7 +36,7 @@
           "DefaultValueForNode": "v1/spec.nodeName"
         },
         {
-          "Name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+          "Name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
           "CSIEnvType": "String",
           "SetForController": false,
           "SetForNode": true,

--- a/samples/powerstore_v220_k8s_121.yaml
+++ b/samples/powerstore_v220_k8s_121.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.2.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v220_k8s_122.yaml
+++ b/samples/powerstore_v220_k8s_122.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.2.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v220_k8s_123.yaml
+++ b/samples/powerstore_v220_k8s_123.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.2.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v220_ops_48.yaml
+++ b/samples/powerstore_v220_ops_48.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.2.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v220_ops_49.yaml
+++ b/samples/powerstore_v220_ops_49.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.2.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v230_k8s_121.yaml
+++ b/samples/powerstore_v230_k8s_121.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.3.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v230_k8s_122.yaml
+++ b/samples/powerstore_v230_k8s_122.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.3.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v230_k8s_123.yaml
+++ b/samples/powerstore_v230_k8s_123.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.3.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v230_k8s_124.yaml
+++ b/samples/powerstore_v230_k8s_124.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.3.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v230_ops_410.yaml
+++ b/samples/powerstore_v230_ops_410.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.3.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v230_ops_49.yaml
+++ b/samples/powerstore_v230_ops_49.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.3.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v240_k8s_121.yaml
+++ b/samples/powerstore_v240_k8s_121.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.4.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v240_k8s_122.yaml
+++ b/samples/powerstore_v240_k8s_122.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.4.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v240_k8s_123.yaml
+++ b/samples/powerstore_v240_k8s_123.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.4.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v240_k8s_124.yaml
+++ b/samples/powerstore_v240_k8s_124.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.4.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v240_ops_410.yaml
+++ b/samples/powerstore_v240_ops_410.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.4.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/samples/powerstore_v240_ops_49.yaml
+++ b/samples/powerstore_v240_ops_49.yaml
@@ -17,7 +17,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.4.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/test/integration-tests/cr/powerstore.json
+++ b/test/integration-tests/cr/powerstore.json
@@ -14,7 +14,7 @@
             "value": "https://10.230.42.95/api/rest"
           },
           {
-            "name": "X_CSI_POWERSTORE_NODE_NAME_PREFIX",
+            "name": "X_CSI_POWERSTORE_KUBE_NODE_NAME",
             "value": "csi"
           },
           {

--- a/test/testdata/csipowerstore/01-simple-deployment/in-csipowerstore.yaml
+++ b/test/testdata/csipowerstore/01-simple-deployment/in-csipowerstore.yaml
@@ -16,7 +16,7 @@ spec:
       image: "dellemc/csi-powerstore:v2.4.0"
       imagePullPolicy: IfNotPresent
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: "csi"
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: "/etc/fc-ports-filter"

--- a/test/testdata/csipowerstore/01-simple-deployment/out-csipowerstore.yaml
+++ b/test/testdata/csipowerstore/01-simple-deployment/out-csipowerstore.yaml
@@ -24,7 +24,7 @@ spec:
   driver:
     common:
       envs:
-        - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+        - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
           value: csi
         - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
           value: /etc/fc-ports-filter

--- a/test/testdata/csipowerstore/01-simple-deployment/out-daemonset.yaml
+++ b/test/testdata/csipowerstore/01-simple-deployment/out-daemonset.yaml
@@ -29,12 +29,12 @@ spec:
               value: csi-powerstore.dellemc.com
             - name: X_CSI_POWERSTORE_TMP_DIR
               value: /var/lib/kubelet/plugins/csi-powerstore.dellemc.com/tmp
-            - name: X_CSI_POWERSTORE_NODENAME
+            - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+            - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
               value: csi
             - name: X_CSI_POWERSTORE_NODE_ID_PATH
               value: /node-id

--- a/test/testdata/csipowerstore/01-simple-deployment/out-statefulset.yaml
+++ b/test/testdata/csipowerstore/01-simple-deployment/out-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
               value: "false"
             - name: X_CSI_NFS_ACLS
               value: "0777"
-            - name: X_CSI_POWERSTORE_NODE_NAME_PREFIX
+            - name: X_CSI_POWERSTORE_KUBE_NODE_NAME
               value: csi
             - name: X_CSI_FC_PORTS_FILTER_FILE_PATH
               value: /etc/fc-ports-filter


### PR DESCRIPTION
…tore

# Description
Renaming environment variable (X_CSI_POWERSTORE_NODE_NAME_PREFIX -> X_CSI_POWERSTORE_KUBE_NODE_NAME) across the repo for PowerStore Array

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Have installed the driver using helm operator's sample file and check if the host got added on the array or not.
