### PR TITLE
CSI-Powerstore: Updated files for the feature Storage Capacity Tracking

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -463,6 +463,10 @@ type Driver struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="FSGroupPolicy"
 	FSGroupPolicy string `json:"fsGroupPolicy,omitempty" yaml:"fsGroupPolicy"`
 
+	// StorageCapacity enables/disables capacity tracking
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Capacity"
+	StorageCapacity bool `json:"storageCapacity,omitempty" yaml:"storageCapacity"`
+
 	// Common is the common specification for both controller and node plugins
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Common specification"
 	Common ContainerTemplate `json:"common" yaml:"common"`

--- a/driverconfig/powerstore_v250_v124.json
+++ b/driverconfig/powerstore_v250_v124.json
@@ -348,12 +348,31 @@
             "--leader-election",
             "--default-fstype=ext4",
             "--feature-gates=Topology=true",
-            "--extra-create-metadata"
+            "--extra-create-metadata",
+            "--enable-capacity=true",
+            "--capacity-ownerref-level=2",
+            "--capacity-poll-interval=5m"
           ],
           "envs": [
             {
               "name": "ADDRESS",
               "value": "/var/run/csi/csi.sock"
+            },
+            {
+              "name": "NAMESPACE",
+              "valueFrom": {
+                "fieldRef": {
+                  "fieldPath": "metadata.namespace"
+                }
+              }
+            },
+            {
+              "name": "POD_NAME",
+              "valueFrom": {
+                "fieldRef": {
+                  "fieldPath": "metadata.name"
+                }
+              }
             }
           ],
           "volumeMounts": [

--- a/driverconfig/powerstore_v250_v125.json
+++ b/driverconfig/powerstore_v250_v125.json
@@ -348,12 +348,31 @@
           "--leader-election",
           "--default-fstype=ext4",
           "--feature-gates=Topology=true",
-          "--extra-create-metadata"
+          "--extra-create-metadata",
+          "--enable-capacity=true",
+          "--capacity-ownerref-level=2",
+          "--capacity-poll-interval=5m"
         ],
         "envs": [
           {
             "name": "ADDRESS",
             "value": "/var/run/csi/csi.sock"
+          },
+          {
+            "name": "NAMESPACE",
+            "valueFrom": {
+              "fieldRef": {
+                "fieldPath": "metadata.namespace"
+              }
+            }
+          },
+          {
+            "name": "POD_NAME",
+            "valueFrom": {
+              "fieldRef": {
+                "fieldPath": "metadata.name"
+              }
+            }
           }
         ],
         "volumeMounts": [

--- a/pkg/resources/csidriver/csidriver.go
+++ b/pkg/resources/csidriver/csidriver.go
@@ -34,6 +34,7 @@ func New(instance csiv1.CSIDriver, ephemeralEnabled bool, dummyClusterRole *rbac
 		AttachRequired:       &b,
 		PodInfoOnMount:       &b,
 		VolumeLifecycleModes: modes,
+		StorageCapacity:      &instance.GetDriver().StorageCapacity,
 	}
 
 	spec.FSGroupPolicy = &fsgroup

--- a/pkg/resources/rbac/controllerrbac.go
+++ b/pkg/resources/rbac/controllerrbac.go
@@ -31,6 +31,7 @@ func NewDummyClusterRole(name string) *rbacv1.ClusterRole {
 func NewControllerClusterRole(instance csiv1.CSIDriver, customClusterRoleName bool, haRequired bool, dummyClusterRole *rbacv1.ClusterRole) *rbacv1.ClusterRole {
 	driverName := instance.GetName()
 	driverNamespace := instance.GetNamespace()
+	driverType := instance.GetDriverType()
 	clusterRoleName := fmt.Sprintf("%s-controller", driverName)
 	if customClusterRoleName {
 		clusterRoleName = fmt.Sprintf("%s-%s-controller", driverNamespace, driverName)
@@ -134,6 +135,18 @@ func NewControllerClusterRole(instance csiv1.CSIDriver, customClusterRoleName bo
 			APIGroups: []string{"coordination.k8s.io"},
 			Resources: []string{"leases"},
 			Verbs:     []string{"create", "get", "list", "watch", "delete", "update"},
+		})
+	}
+	if driverType == "powerstore" {
+		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{"storage.k8s.io"},
+			Resources: []string{"csistoragecapacities"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		})
+		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{"apps"},
+			Resources: []string{"replicasets"},
+			Verbs:     []string{"get"},
 		})
 	}
 	return clusterRole

--- a/samples/powerstore_v250_k8s_124.yaml
+++ b/samples/powerstore_v250_k8s_124.yaml
@@ -12,6 +12,7 @@ spec:
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     fsGroupPolicy: ReadWriteOnceWithFSType
+    storageCapacity: true
     common:
       # Image for CSI PowerStore driver v2.5.0
       image: "dellemc/csi-powerstore:v2.5.0"
@@ -26,6 +27,12 @@ spec:
       # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED to "true".
       #- name: external-health-monitor
       #  args: ["--monitor-interval=60s"]
+
+      # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+      # Configure when the storageCapacity is set as "true"
+      # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=10m"]
 
     controller:
       envs:

--- a/samples/powerstore_v250_k8s_124.yaml
+++ b/samples/powerstore_v250_k8s_124.yaml
@@ -32,7 +32,7 @@ spec:
       # Configure when the storageCapacity is set as "true"
       # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
       #- name: provisioner
-      #  args: ["--capacity-poll-interval=10m"]
+      #  args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:

--- a/samples/powerstore_v250_k8s_125.yaml
+++ b/samples/powerstore_v250_k8s_125.yaml
@@ -12,6 +12,7 @@ spec:
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     fsGroupPolicy: ReadWriteOnceWithFSType
+    storageCapacity: true
     common:
       # Image for CSI PowerStore driver v2.5.0
       image: "dellemc/csi-powerstore:v2.5.0"
@@ -26,6 +27,12 @@ spec:
       # Also set the env variable controller.envs.X_CSI_HEALTH_MONITOR_ENABLED to "true".
       #- name: external-health-monitor
       #  args: ["--monitor-interval=60s"]
+
+      # Uncomment the following to configure how often external-provisioner polls the driver to detect changed capacity
+      # Configure when the storageCapacity is set as "true"
+      # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
+      #- name: provisioner
+      #  args: ["--capacity-poll-interval=10m"]
 
     controller:
       envs:

--- a/samples/powerstore_v250_k8s_125.yaml
+++ b/samples/powerstore_v250_k8s_125.yaml
@@ -32,7 +32,7 @@ spec:
       # Configure when the storageCapacity is set as "true"
       # Allowed values: 1m,2m,3m,...,10m,...,60m etc. Default value: 5m
       #- name: provisioner
-      #  args: ["--capacity-poll-interval=10m"]
+      #  args: ["--capacity-poll-interval=5m"]
 
     controller:
       envs:

--- a/test/testdata/csiisilon/01-simple-deployment/in-csiisilon.yaml
+++ b/test/testdata/csiisilon/01-simple-deployment/in-csiisilon.yaml
@@ -10,6 +10,7 @@ spec:
     replicas: 1
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    storageCapacity: false
     common:
       # Image for CSI PowerScale driver v2.4.0
       image: "dellemc/csi-isilon:v2.4.0"

--- a/test/testdata/csiisilon/01-simple-deployment/out-csidriver.yaml
+++ b/test/testdata/csiisilon/01-simple-deployment/out-csidriver.yaml
@@ -10,6 +10,7 @@ spec:
   attachRequired: true
   podInfoOnMount: true
   fsGroupPolicy: "ReadWriteOnceWithFSType"
+  storageCapacity: false
   volumeLifecycleModes:
   - Persistent
   - Ephemeral

--- a/test/testdata/csipowermax/01-simple-deployment/in-csipowermax.yaml
+++ b/test/testdata/csipowermax/01-simple-deployment/in-csipowermax.yaml
@@ -11,6 +11,7 @@ spec:
     replicas: 1
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    storageCapacity: false
     common:
       # Image for CSI PowerMax driver v2.4.0
       image: "dellemc/csi-powermax:v2.4.0"

--- a/test/testdata/csipowermax/01-simple-deployment/out-csidriver.yaml
+++ b/test/testdata/csipowermax/01-simple-deployment/out-csidriver.yaml
@@ -12,5 +12,6 @@ spec:
   attachRequired: true
   podInfoOnMount: true
   fsGroupPolicy: "ReadWriteOnceWithFSType"
+  storageCapacity: false
   volumeLifecycleModes:
     - Persistent

--- a/test/testdata/csipowerstore/01-simple-deployment/in-csipowerstore.yaml
+++ b/test/testdata/csipowerstore/01-simple-deployment/in-csipowerstore.yaml
@@ -11,6 +11,7 @@ spec:
     replicas: 1
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
+    storageCapacity: false
     common:
       # Image for CSI PowerStore driver v2.5.0
       # @TO-DO need to replace 2.4.0 with 2.5.0 once image is available

--- a/test/testdata/csipowerstore/01-simple-deployment/out-clusterrole-controller.yaml
+++ b/test/testdata/csipowerstore/01-simple-deployment/out-clusterrole-controller.yaml
@@ -167,3 +167,21 @@ rules:
       - watch
       - delete
       - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csistoragecapacities
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get

--- a/test/testdata/csipowerstore/01-simple-deployment/out-csidriver.yaml
+++ b/test/testdata/csipowerstore/01-simple-deployment/out-csidriver.yaml
@@ -12,6 +12,7 @@ spec:
   attachRequired: true
   podInfoOnMount: true
   fsGroupPolicy: "ReadWriteOnceWithFSType"
+  storageCapacity: false
   volumeLifecycleModes:
     - Persistent
     - Ephemeral

--- a/test/testdata/csivxflexos/01-simple-deployment/in-csidriverdeployment.yaml
+++ b/test/testdata/csivxflexos/01-simple-deployment/in-csidriverdeployment.yaml
@@ -10,6 +10,7 @@ spec:
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     fsGroupPolicy: File
+    storageCapacity: false
     common:
       image: "dellemc/csi-vxflexos:v2.4.0"
       imagePullPolicy: IfNotPresent

--- a/test/testdata/csivxflexos/01-simple-deployment/out-csidriver.yaml
+++ b/test/testdata/csivxflexos/01-simple-deployment/out-csidriver.yaml
@@ -12,6 +12,7 @@ spec:
   attachRequired: true
   podInfoOnMount: true
   fsGroupPolicy: File
+  storageCapacity: false
   volumeLifecycleModes:
     - Persistent
     - Ephemeral


### PR DESCRIPTION
# Description
Updated files to support the feature Storage Capacity Tracking in CSI-Powerstore driver.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/483 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the driver by enabling/disabling the feature and the driver description showed the expected changes.
- [x] Created manual pods to test the storage capacity tracking feature; the pods did not go to ContainerCreating state when the capacity was not available on the node as expected.
