### PR TITLE
CSI Powermax: Reverse Proxy mandate

### DIFF
--- a/driverconfig/powermax_v250_v121.json
+++ b/driverconfig/powermax_v250_v121.json
@@ -211,8 +211,8 @@
         "CSIEnvType": "String",
         "SetForController": true,
         "SetForNode": true,
-        "DefaultValueForController": "none",
-        "DefaultValueForNode": "none"
+        "DefaultValueForController": "powermax-reverseproxy",
+        "DefaultValueForNode": "powermax-reverseproxy"
       },
       {
         "Name": "X_CSI_ReplicationContextPrefix",

--- a/driverconfig/powermax_v250_v123.json
+++ b/driverconfig/powermax_v250_v123.json
@@ -211,8 +211,8 @@
         "CSIEnvType": "String",
         "SetForController": true,
         "SetForNode": true,
-        "DefaultValueForController": "none",
-        "DefaultValueForNode": "none"
+        "DefaultValueForController": "powermax-reverseproxy",
+        "DefaultValueForNode": "powermax-reverseproxy"
       },
       {
         "Name": "X_CSI_ReplicationContextPrefix",

--- a/driverconfig/powermax_v250_v124.json
+++ b/driverconfig/powermax_v250_v124.json
@@ -211,8 +211,8 @@
         "CSIEnvType": "String",
         "SetForController": true,
         "SetForNode": true,
-        "DefaultValueForController": "none",
-        "DefaultValueForNode": "none"
+        "DefaultValueForController": "powermax-reverseproxy",
+        "DefaultValueForNode": "powermax-reverseproxy"
       },
       {
         "Name": "X_CSI_ReplicationContextPrefix",

--- a/driverconfig/powermax_v250_v125.json
+++ b/driverconfig/powermax_v250_v125.json
@@ -211,8 +211,8 @@
         "CSIEnvType": "String",
         "SetForController": true,
         "SetForNode": true,
-        "DefaultValueForController": "none",
-        "DefaultValueForNode": "none"
+        "DefaultValueForController": "powermax-reverseproxy",
+        "DefaultValueForNode": "powermax-reverseproxy"
       },
       {
         "Name": "X_CSI_ReplicationContextPrefix",

--- a/samples/powermax_revproxy_standalone_with_driver.yaml
+++ b/samples/powermax_revproxy_standalone_with_driver.yaml
@@ -126,11 +126,10 @@ spec:
         - name: X_CSI_TRANSPORT_PROTOCOL
           value: ""
         # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Set this to "powermax-reverseproxy" if you are installing the proxy
         # Allowed values: "powermax-reverseproxy"
-        # default values: "" <empty>
+        # default values: "powermax-reverseproxy"
         - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-          value: ""
+          value: "powermax-reverseproxy"
           # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.
           # Set this value to a higher number (max 50) if you are using the proxy
           # Allowed values: n, where n > 4

--- a/samples/powermax_v250_k8s_121.yaml
+++ b/samples/powermax_v250_k8s_121.yaml
@@ -63,11 +63,10 @@ spec:
         - name: "X_CSI_TRANSPORT_PROTOCOL"
           value: ""
         # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Set this to "powermax-reverseproxy" if you are installing the proxy
         # Allowed values: "powermax-reverseproxy"
-        # default values: "" <empty>
+        # default values: "powermax-reverseproxy"
         - name: "X_CSI_POWERMAX_PROXY_SERVICE_NAME"
-          value: ""
+          value: "powermax-reverseproxy"
         # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.
         # Set this value to a higher number (max 50) if you are using the proxy
         # Allowed values: n, where n > 4

--- a/samples/powermax_v250_k8s_123.yaml
+++ b/samples/powermax_v250_k8s_123.yaml
@@ -63,11 +63,10 @@ spec:
         - name: "X_CSI_TRANSPORT_PROTOCOL"
           value: ""
         # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Set this to "powermax-reverseproxy" if you are installing the proxy
         # Allowed values: "powermax-reverseproxy"
-        # default values: "" <empty>
+        # default values: "powermax-reverseproxy"
         - name: "X_CSI_POWERMAX_PROXY_SERVICE_NAME"
-          value: ""
+          value: "powermax-reverseproxy"
         # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.
         # Set this value to a higher number (max 50) if you are using the proxy
         # Allowed values: n, where n > 4

--- a/samples/powermax_v250_k8s_124.yaml
+++ b/samples/powermax_v250_k8s_124.yaml
@@ -63,11 +63,10 @@ spec:
         - name: "X_CSI_TRANSPORT_PROTOCOL"
           value: ""
         # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Set this to "powermax-reverseproxy" if you are installing the proxy
         # Allowed values: "powermax-reverseproxy"
-        # default values: "" <empty>
+        # default values: "powermax-reverseproxy"
         - name: "X_CSI_POWERMAX_PROXY_SERVICE_NAME"
-          value: ""
+          value: "powermax-reverseproxy"
         # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.
         # Set this value to a higher number (max 50) if you are using the proxy
         # Allowed values: n, where n > 4

--- a/samples/powermax_v250_k8s_125.yaml
+++ b/samples/powermax_v250_k8s_125.yaml
@@ -66,7 +66,7 @@ spec:
         # Allowed values: "powermax-reverseproxy"
         # default values: "powermax-reverseproxy"
         - name: "X_CSI_POWERMAX_PROXY_SERVICE_NAME"
-          value: ""
+          value: "powermax-reverseproxy"
         # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.
         # Set this value to a higher number (max 50) if you are using the proxy
         # Allowed values: n, where n > 4

--- a/samples/powermax_v250_k8s_125.yaml
+++ b/samples/powermax_v250_k8s_125.yaml
@@ -63,9 +63,8 @@ spec:
         - name: "X_CSI_TRANSPORT_PROTOCOL"
           value: ""
         # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Set this to "powermax-reverseproxy" if you are installing the proxy
         # Allowed values: "powermax-reverseproxy"
-        # default values: "" <empty>
+        # default values: "powermax-reverseproxy"
         - name: "X_CSI_POWERMAX_PROXY_SERVICE_NAME"
           value: ""
         # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.

--- a/samples/powermax_v250_ops_410.yaml
+++ b/samples/powermax_v250_ops_410.yaml
@@ -63,11 +63,10 @@ spec:
         - name: "X_CSI_TRANSPORT_PROTOCOL"
           value: ""
         # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Set this to "powermax-reverseproxy" if you are installing the proxy
         # Allowed values: "powermax-reverseproxy"
-        # default values: "" <empty>
+        # default values: "powermax-reverseproxy"
         - name: "X_CSI_POWERMAX_PROXY_SERVICE_NAME"
-          value: ""
+          value: "powermax-reverseproxy"
         # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.
         # Set this value to a higher number (max 50) if you are using the proxy
         # Allowed values: n, where n > 4

--- a/samples/powermax_v250_ops_411.yaml
+++ b/samples/powermax_v250_ops_411.yaml
@@ -63,11 +63,10 @@ spec:
         - name: "X_CSI_TRANSPORT_PROTOCOL"
           value: ""
         # X_CSI_POWERMAX_PROXY_SERVICE_NAME: Refers to the name of the proxy service in kubernetes
-        # Set this to "powermax-reverseproxy" if you are installing the proxy
         # Allowed values: "powermax-reverseproxy"
-        # default values: "" <empty>
+        # default values: "powermax-reverseproxy"
         - name: "X_CSI_POWERMAX_PROXY_SERVICE_NAME"
-          value: ""
+          value: "powermax-reverseproxy"
         # X_CSI_GRPC_MAX_THREADS: Defines the maximum number of concurrent grpc requests.
         # Set this value to a higher number (max 50) if you are using the proxy
         # Allowed values: n, where n > 4

--- a/test/testdata/csipowermax/01-simple-deployment/out-daemonset.yaml
+++ b/test/testdata/csipowermax/01-simple-deployment/out-daemonset.yaml
@@ -73,7 +73,7 @@ spec:
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "false"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: "none"
+              value: "powermax-reverseproxy"
             - name: X_CSI_UNISPHERE_TIMEOUT
               value: 5m
             - name: X_CSI_POWERMAX_CONFIG_PATH

--- a/test/testdata/csipowermax/01-simple-deployment/out-deployment.yaml
+++ b/test/testdata/csipowermax/01-simple-deployment/out-deployment.yaml
@@ -77,7 +77,7 @@ spec:
             - name: X_CSI_IG_MODIFY_HOSTNAME
               value: "false"
             - name: X_CSI_POWERMAX_PROXY_SERVICE_NAME
-              value: none
+              value: "powermax-reverseproxy"
             - name: X_CSI_ReplicationContextPrefix
               value: powermax/
             - name: X_CSI_ReplicationPrefix


### PR DESCRIPTION
# Description
These changes make the installation of CSI reverse proxy mandatory with the v2.5 CSI powermax.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/495|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] Unit Tests
- [x] Cluster Test: Installation
