### PR TITLE
Added RBAC permissions for csistoragecapacities resource in manifests

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -259,6 +259,18 @@ rules:
 - apiGroups:
   - storage.k8s.io
   resources:
+  - csistoragecapacities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
   - storageclasses
   verbs:
   - create

--- a/controllers/csipowerstore_controller.go
+++ b/controllers/csipowerstore_controller.go
@@ -68,6 +68,7 @@ type CSIPowerStoreReconciler struct {
 // +kubebuilder:rbac:groups="storage.k8s.io",resources=volumeattachments/status,verbs=patch
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,resourceNames=privileged,verbs=use
+// +kubebuilder:rbac:groups="storage.k8s.io",resources=csistoragecapacities,verbs=get;list;watch;create;update;patch;delete
 
 //Reconcile function reconciles a CSIPowerStore Object
 func (r *CSIPowerStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -299,6 +299,18 @@ rules:
 - apiGroups:
   - storage.k8s.io
   resources:
+  - csistoragecapacities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
   - storageclasses
   verbs:
   - create


### PR DESCRIPTION
# Description
Added RBAC permissions in manifest files for the resource `csistoragecapacities`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/483 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the operator via latest image build from this branch and installed the driver. The driver pods were running.

![operator and driver pods](https://user-images.githubusercontent.com/109594002/199919333-b04139d7-056b-419a-9f2e-54422ca1e525.PNG)

- [x] Verified the resource `csistoragecapacities` being created in the operator clusterrole `dell-csi-operator-manager-role`

![image](https://user-images.githubusercontent.com/109594002/199919824-b139295e-cfd1-46ce-9845-d98ab1cb424d.png)
