### PR TITLE
Fix for secrets getting regenerated on apply of driver manifest

### DIFF
--- a/pkg/resources/serviceaccount/serviceaccount.go
+++ b/pkg/resources/serviceaccount/serviceaccount.go
@@ -42,11 +42,9 @@ func SyncServiceAccount(ctx context.Context, sa *corev1.ServiceAccount, client c
 		reqLogger.Info("Unknown error.", "Error", err.Error())
 		return err
 	} else {
-		reqLogger.Info("Updating ServiceAccount", "Name:", sa.Name)
-		err = client.Update(ctx, sa)
-		if err != nil {
-			return err
-		}
+		// Updating the service account keeps regenerating the secrets.
+		// We dont have to update the service account if it exists.
+		reqLogger.Info("ServiceAccount already exists", "Name:", sa.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description
This commit fixes the issue of secrets getting regenerated every time the driver manifest is applied

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/485 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
1. Install operator followed by install of driver. Apply the driver manifest couple of times (both with and without any changes) and ensure that secrets are not regenerated. Tested this on OCP 4.10 and OCP 4.11
