### PR TITLE
Added storageCapacity spec in Powerstore OpenShift samples

### DIFF
--- a/samples/powerstore_v250_ops_410.yaml
+++ b/samples/powerstore_v250_ops_410.yaml
@@ -12,6 +12,7 @@ spec:
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     fsGroupPolicy: ReadWriteOnceWithFSType
+    storageCapacity: true
     common:
       # Image for CSI PowerStore driver v2.5.0
       image: "dellemc/csi-powerstore:v2.5.0"

--- a/samples/powerstore_v250_ops_411.yaml
+++ b/samples/powerstore_v250_ops_411.yaml
@@ -12,6 +12,7 @@ spec:
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     fsGroupPolicy: ReadWriteOnceWithFSType
+    storageCapacity: true
     common:
       # Image for CSI PowerStore driver v2.5.0
       image: "dellemc/csi-powerstore:v2.5.0"


### PR DESCRIPTION
# Description
Added support for Storage Capacity Tracking in OpenShift.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/483 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed operator from the latest image and installed the latest powerstore driver. The operator and driver pods were running successfully on the OpenShift cluster.
- [x] Verified the spec Storage Capacity being enabled as true when the csi driver is described.
