### PR TITLE
unresolvable hosts changes

### DIFF
--- a/config/samples/storage_v1_csiisilon.yaml
+++ b/config/samples/storage_v1_csiisilon.yaml
@@ -117,6 +117,16 @@ spec:
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
 
+      # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS
+      # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+      # same exports are unresolvable/doesn't exist anymore.
+      # Allowed values:
+      #   true: ignore existing unresolvable hosts and append new host to the existing export
+      #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+      # Default value: false
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "false"
+
       # nodeSelector: Define node selection constraints for pods of controller deployment.
       # For the pod to be eligible to run on a node, the node must have each
       # of the indicated key-value pairs as labels.

--- a/driverconfig/isilon_v250_v121.json
+++ b/driverconfig/isilon_v250_v121.json
@@ -117,6 +117,14 @@
         "DefaultValueForNode": ""
       },
       {
+        "Name": "X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": false,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": ""
+      },
+      {
         "Name": "X_CSI_HEALTH_MONITOR_ENABLED",
         "CSIEnvType": "String",
         "SetForController": true,

--- a/driverconfig/isilon_v250_v123.json
+++ b/driverconfig/isilon_v250_v123.json
@@ -117,6 +117,14 @@
         "DefaultValueForNode": ""
       },
       {
+        "Name": "X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": false,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": ""
+      },
+      {
         "Name": "X_CSI_HEALTH_MONITOR_ENABLED",
         "CSIEnvType": "String",
         "SetForController": true,

--- a/driverconfig/isilon_v250_v124.json
+++ b/driverconfig/isilon_v250_v124.json
@@ -117,6 +117,14 @@
         "DefaultValueForNode": ""
       },
       {
+        "Name": "X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": false,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": ""
+      },
+      {
         "Name": "X_CSI_HEALTH_MONITOR_ENABLED",
         "CSIEnvType": "String",
         "SetForController": true,

--- a/driverconfig/isilon_v250_v125.json
+++ b/driverconfig/isilon_v250_v125.json
@@ -117,6 +117,14 @@
         "DefaultValueForNode": ""
       },
       {
+        "Name": "X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS",
+        "CSIEnvType": "Boolean",
+        "SetForController": true,
+        "SetForNode": false,
+        "DefaultValueForController": "false",
+        "DefaultValueForNode": ""
+      },
+      {
         "Name": "X_CSI_HEALTH_MONITOR_ENABLED",
         "CSIEnvType": "String",
         "SetForController": true,

--- a/samples/isilon_v250_k8s_121.yaml
+++ b/samples/isilon_v250_k8s_121.yaml
@@ -117,6 +117,16 @@ spec:
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
 
+      # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS
+      # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+      # same exports are unresolvable/doesn't exist anymore.
+      # Allowed values:
+      #   true: ignore existing unresolvable hosts and append new host to the existing export
+      #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+      # Default value: false
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "false"
+
       # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
       # Install the 'external-health-monitor' sidecar accordingly.
       # Allowed values:

--- a/samples/isilon_v250_k8s_123.yaml
+++ b/samples/isilon_v250_k8s_123.yaml
@@ -2,18 +2,18 @@ apiVersion: storage.dell.com/v1
 kind: CSIIsilon
 metadata:
   name: isilon
-  namespace: isilon
+  namespace: test-isilon
 spec:
   driver:
     # Config version for CSI PowerScale v2.5.0 driver
     configVersion: v2.5.0
-    replicas: 1
+    replicas: 2
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerScale driver v2.5.0
-      image: "amaas-eos-mw1.cec.lab.emc.com:5028/csi-isilon/isilon:20221118054506"
+      image: "dellemc/csi-isilon:v2.5.0"
       imagePullPolicy: IfNotPresent
       envs:
         # X_CSI_VERBOSE: Indicates what content of the OneFS REST API message should be logged in debug level logs
@@ -125,7 +125,7 @@ spec:
       #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
       # Default value: false
       - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
-        value: "true"
+        value: "false"
 
       # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
       # Install the 'external-health-monitor' sidecar accordingly.
@@ -143,18 +143,12 @@ spec:
       # Allowed values: map of key-value pairs
       # Default value: None
       nodeSelector:
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-      #  node-role.kubernetes.io/master: ""
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
       #  node-role.kubernetes.io/control-plane: ""
 
       # tolerations: Define tolerations for the controller deployment, if required.
       # Default value: None
       tolerations:
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-      # - key: "node-role.kubernetes.io/master"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
@@ -195,8 +189,6 @@ spec:
       # Allowed values: map of key-value pairs
       # Default value: None
       nodeSelector:
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-      #  node-role.kubernetes.io/master: ""
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
       #  node-role.kubernetes.io/control-plane: ""
 
@@ -212,10 +204,6 @@ spec:
       #  - key: "node.kubernetes.io/network-unavailable"
       #    operator: "Exists"
       #    effect: "NoExecute"
-      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
-      # - key: "node-role.kubernetes.io/master"
-      #   operator: "Exists"
-      #   effect: "NoSchedule"
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
@@ -235,7 +223,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: isilon-config-params
-  namespace: isilon
+  namespace: test-isilon
 data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "debug"

--- a/samples/isilon_v250_k8s_123.yaml
+++ b/samples/isilon_v250_k8s_123.yaml
@@ -143,12 +143,18 @@ spec:
       # Allowed values: map of key-value pairs
       # Default value: None
       nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
       #  node-role.kubernetes.io/control-plane: ""
 
       # tolerations: Define tolerations for the controller deployment, if required.
       # Default value: None
       tolerations:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"
@@ -189,6 +195,8 @@ spec:
       # Allowed values: map of key-value pairs
       # Default value: None
       nodeSelector:
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      #  node-role.kubernetes.io/master: ""
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
       #  node-role.kubernetes.io/control-plane: ""
 
@@ -204,6 +212,10 @@ spec:
       #  - key: "node.kubernetes.io/network-unavailable"
       #    operator: "Exists"
       #    effect: "NoExecute"
+      # Uncomment if nodes you wish to use have the node-role.kubernetes.io/master taint
+      # - key: "node-role.kubernetes.io/master"
+      #   operator: "Exists"
+      #   effect: "NoSchedule"
       # Uncomment if nodes you wish to use have the node-role.kubernetes.io/control-plane taint
       # - key: "node-role.kubernetes.io/control-plane"
       #   operator: "Exists"

--- a/samples/isilon_v250_k8s_123.yaml
+++ b/samples/isilon_v250_k8s_123.yaml
@@ -2,18 +2,18 @@ apiVersion: storage.dell.com/v1
 kind: CSIIsilon
 metadata:
   name: isilon
-  namespace: test-isilon
+  namespace: isilon
 spec:
   driver:
     # Config version for CSI PowerScale v2.5.0 driver
     configVersion: v2.5.0
-    replicas: 2
+    replicas: 1
     dnsPolicy: ClusterFirstWithHostNet
     forceUpdate: false
     fsGroupPolicy: ReadWriteOnceWithFSType
     common:
       # Image for CSI PowerScale driver v2.5.0
-      image: "dellemc/csi-isilon:v2.5.0"
+      image: "amaas-eos-mw1.cec.lab.emc.com:5028/csi-isilon/isilon:20221118054506"
       imagePullPolicy: IfNotPresent
       envs:
         # X_CSI_VERBOSE: Indicates what content of the OneFS REST API message should be logged in debug level logs
@@ -116,6 +116,16 @@ spec:
       # Examples: "0777", "777", "0755"
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
+
+      # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS
+      # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+      # same exports are unresolvable/doesn't exist anymore.
+      # Allowed values:
+      #   true: ignore existing unresolvable hosts and append new host to the existing export
+      #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+      # Default value: false
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "true"
 
       # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
       # Install the 'external-health-monitor' sidecar accordingly.
@@ -225,7 +235,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: isilon-config-params
-  namespace: test-isilon
+  namespace: isilon
 data:
   driver-config-params.yaml: |
     CSI_LOG_LEVEL: "debug"

--- a/samples/isilon_v250_k8s_124.yaml
+++ b/samples/isilon_v250_k8s_124.yaml
@@ -117,6 +117,16 @@ spec:
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
 
+      # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS
+      # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+      # same exports are unresolvable/doesn't exist anymore.
+      # Allowed values:
+      #   true: ignore existing unresolvable hosts and append new host to the existing export
+      #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+      # Default value: false
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "false"
+
       # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
       # Install the 'external-health-monitor' sidecar accordingly.
       # Allowed values:

--- a/samples/isilon_v250_k8s_125.yaml
+++ b/samples/isilon_v250_k8s_125.yaml
@@ -117,6 +117,16 @@ spec:
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
 
+      # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS
+      # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+      # same exports are unresolvable/doesn't exist anymore.
+      # Allowed values:
+      #   true: ignore existing unresolvable hosts and append new host to the existing export
+      #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+      # Default value: false
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "false"
+
       # X_CSI_HEALTH_MONITOR_ENABLED: Enable/Disable health monitor of CSI volumes from Controller plugin- volume status, volume condition.
       # Install the 'external-health-monitor' sidecar accordingly.
       # Allowed values:

--- a/samples/isilon_v250_ops_410.yaml
+++ b/samples/isilon_v250_ops_410.yaml
@@ -117,6 +117,16 @@ spec:
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
 
+      # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS
+      # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+      # same exports are unresolvable/doesn't exist anymore.
+      # Allowed values:
+      #   true: ignore existing unresolvable hosts and append new host to the existing export
+      #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+      # Default value: false
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "false"
+
       # nodeSelector: Define node selection constraints for pods of controller deployment.
       # For the pod to be eligible to run on a node, the node must have each
       # of the indicated key-value pairs as labels.

--- a/samples/isilon_v250_ops_411.yaml
+++ b/samples/isilon_v250_ops_411.yaml
@@ -117,6 +117,16 @@ spec:
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
 
+      # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS
+      # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+      # same exports are unresolvable/doesn't exist anymore.
+      # Allowed values:
+      #   true: ignore existing unresolvable hosts and append new host to the existing export
+      #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+      # Default value: false
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "false"
+
       # nodeSelector: Define node selection constraints for pods of controller deployment.
       # For the pod to be eligible to run on a node, the node must have each
       # of the indicated key-value pairs as labels.

--- a/test/testdata/csiisilon/01-simple-deployment/in-csiisilon.yaml
+++ b/test/testdata/csiisilon/01-simple-deployment/in-csiisilon.yaml
@@ -111,6 +111,16 @@ spec:
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
 
+      # X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS: Ignore unresolvable hosts on the OneFS
+      # When set to true, OneFS allows new host to add to existing export list though any of the existing hosts from the
+      # same exports are unresolvable/doesn't exist anymore.
+      # Allowed values:
+      #   true: ignore existing unresolvable hosts and append new host to the existing export
+      #   false: exhibits OneFS default behavior i.e. if any of existing hosts are unresolvable while adding new one it fails
+      # Default value: false
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "false"
+
     node:
       envs:
       # X_CSI_MAX_VOLUMES_PER_NODE: Specify default value for maximum number of volumes that controller can publish to the node.

--- a/test/testdata/csiisilon/01-simple-deployment/out-csiisilon.yaml
+++ b/test/testdata/csiisilon/01-simple-deployment/out-csiisilon.yaml
@@ -51,6 +51,8 @@ spec:
         value: System
       - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
         value: "0777"
+      - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+        value: "false"
     dnsPolicy: ClusterFirstWithHostNet
     node:
       envs:

--- a/test/testdata/csiisilon/01-simple-deployment/out-deployment.yaml
+++ b/test/testdata/csiisilon/01-simple-deployment/out-deployment.yaml
@@ -58,6 +58,8 @@ spec:
           value: "false"
         - name: X_CSI_ISI_VOLUME_PATH_PERMISSIONS
           value: "0777"
+        - name: X_CSI_ISI_IGNORE_UNRESOLVABLE_HOSTS
+          value: "false"
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
         - name: X_CSI_VERBOSE


### PR DESCRIPTION
# Description
These changes allow user to set "ignoreUnresolvableHosts" param from dell-csi-operator.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/534|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran sanity and added unresolvable hosts to OneFS clients list. It works.
