### PR TITLE
added the support for 3.6.0.6 rhel sdc.

### DIFF
--- a/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
@@ -366,7 +366,7 @@ metadata:
                       "value": "10.x.x.x,10.x.x.x"
                     }
                   ],
-                  "image": "dellemc/sdc:3.6",
+                  "image": "dellemc/sdc:3.6.0.6",
                   "imagePullPolicy": "IfNotPresent",
                   "name": "sdc"
                 }

--- a/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
+++ b/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
@@ -366,7 +366,7 @@ metadata:
                       "value": "10.x.x.x,10.x.x.x"
                     }
                   ],
-                  "image": "dellemc/sdc:3.6",
+                  "image": "dellemc/sdc:3.6.0.6",
                   "imagePullPolicy": "IfNotPresent",
                   "name": "sdc"
                 }

--- a/config/samples/storage_v1_csivxflexos.yaml
+++ b/config/samples/storage_v1_csivxflexos.yaml
@@ -84,7 +84,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/driverconfig/config.yaml
+++ b/driverconfig/config.yaml
@@ -269,25 +269,25 @@ extensions:
   - name: sdc-monitor
     images:
       - version: v121
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
       - version: v122
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
       - version: v123
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
       - version: v124
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
       - version: v125
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
   - name: sdc
     images:
       - version: v121
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
       - version: v122
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
       - version: v123
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
       - version: v124
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
       - version: v125
-        tag: dellemc/sdc:3.6
+        tag: dellemc/sdc:3.6.0.6
 

--- a/samples/vxflex_v230_k8s_121.yaml
+++ b/samples/vxflex_v230_k8s_121.yaml
@@ -108,7 +108,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v230_k8s_122.yaml
+++ b/samples/vxflex_v230_k8s_122.yaml
@@ -108,7 +108,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v230_k8s_123.yaml
+++ b/samples/vxflex_v230_k8s_123.yaml
@@ -109,7 +109,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v230_k8s_124.yaml
+++ b/samples/vxflex_v230_k8s_124.yaml
@@ -102,7 +102,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v230_ops_410.yaml
+++ b/samples/vxflex_v230_ops_410.yaml
@@ -88,7 +88,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v230_ops_49.yaml
+++ b/samples/vxflex_v230_ops_49.yaml
@@ -88,7 +88,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v240_k8s_121.yaml
+++ b/samples/vxflex_v240_k8s_121.yaml
@@ -108,7 +108,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v240_k8s_122.yaml
+++ b/samples/vxflex_v240_k8s_122.yaml
@@ -108,7 +108,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v240_k8s_123.yaml
+++ b/samples/vxflex_v240_k8s_123.yaml
@@ -108,7 +108,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v240_k8s_124.yaml
+++ b/samples/vxflex_v240_k8s_124.yaml
@@ -108,7 +108,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v240_ops_410.yaml
+++ b/samples/vxflex_v240_ops_410.yaml
@@ -88,7 +88,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v240_ops_49.yaml
+++ b/samples/vxflex_v240_ops_49.yaml
@@ -88,7 +88,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v250_k8s_121.yaml
+++ b/samples/vxflex_v250_k8s_121.yaml
@@ -104,7 +104,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v250_k8s_123.yaml
+++ b/samples/vxflex_v250_k8s_123.yaml
@@ -104,7 +104,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v250_k8s_124.yaml
+++ b/samples/vxflex_v250_k8s_124.yaml
@@ -92,7 +92,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v250_k8s_125.yaml
+++ b/samples/vxflex_v250_k8s_125.yaml
@@ -92,7 +92,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v250_ops_410.yaml
+++ b/samples/vxflex_v250_ops_410.yaml
@@ -84,7 +84,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/samples/vxflex_v250_ops_411.yaml
+++ b/samples/vxflex_v250_ops_411.yaml
@@ -72,7 +72,7 @@ spec:
       #   effect: "NoSchedule"
 
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/test/testdata/csivxflexos/01-simple-deployment/in-csidriverdeployment.yaml
+++ b/test/testdata/csivxflexos/01-simple-deployment/in-csidriverdeployment.yaml
@@ -34,7 +34,7 @@ spec:
        - name: external-health-monitor
          args: ["--monitor-interval=60s"]
     initContainers:
-      - image: dellemc/sdc:3.6
+      - image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         envs:

--- a/test/testdata/csivxflexos/01-simple-deployment/out-csivxflexos.yaml
+++ b/test/testdata/csivxflexos/01-simple-deployment/out-csivxflexos.yaml
@@ -39,7 +39,7 @@ spec:
     - envs:
       - name: MDM
         value: 10.247.32.32,10.247.90.21
-      image: dellemc/sdc:3.6
+      image: dellemc/sdc:3.6.0.6
       imagePullPolicy: IfNotPresent
       name: sdc
     node: {}

--- a/test/testdata/csivxflexos/01-simple-deployment/out-daemonset.yaml
+++ b/test/testdata/csivxflexos/01-simple-deployment/out-daemonset.yaml
@@ -128,7 +128,7 @@ spec:
               key: password
               name: sdc-repo-creds
               optional: true
-        image: dellemc/sdc:3.6
+        image: dellemc/sdc:3.6.0.6
         imagePullPolicy: IfNotPresent
         name: sdc
         resources: {}


### PR DESCRIPTION
# Description
With the new release of sdc:3.6.0.6 the automatic sdc installation is now also supported on rhel7.9 and rhel 8.x along with RHCOS. This pr addresses the changes in dell-csi-operator  for the sdc:3.6.0.6 support in the csi-powerflex driver.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/554 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] This sdc was Qualified with csi-powerflex using the csi-operator
