### PR TITLE
Bump up operator version to 1.11.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,9 +18,8 @@
 # Nitesh Rewatkar (nitesh3108)
 # Prasanna Muthukumaraswamy (prablr79)
 # Rajendra Indukuri (rajendraindukuri)
-# Randeep Sharma (randeepsharma)
 # Rensy Thomas (rensyct)
 # Spandita Panigrahi (panigs7)
 
 # for all files:
-* @abhi16394 @bpjain2004 @boyamurthy @Deepak-Ghivari @francis-nijay @karthikk92 @bandak2 @mjsdell @nitesh3108 @prablr79 @rajendraindukuri @randeepsharma @rensyct @panigs7
+* @abhi16394 @bpjain2004 @boyamurthy @Deepak-Ghivari @francis-nijay @karthikk92 @bandak2 @mjsdell @nitesh3108 @prablr79 @rajendraindukuri @rensyct @panigs7

--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -3,6 +3,7 @@ general:
     # list of CVEs that are currently unfixed
     - CVE-2022-42898
     - CVE-2022-21698
+    - CVE-2019-1010022
   bestPracticeViolations:
     # list of best practies violatied that needs a fix
     - DKL-DI-0006

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ LABEL vendor="Dell Inc." \
       name="dell-csi-operator" \
       summary="Operator for installing Dell CSI drivers" \
       description="Common Operator for installing various Dell CSI drivers" \
-      version="1.10.0" \
+      version="1.11.0" \
       license="Dell CSI Operator EULA"
 # copy the licenses folder
 COPY licenses /licenses

--- a/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
+++ b/bundle/manifests/dell-csi-operator-certified.clusterserviceversion.yaml
@@ -428,13 +428,13 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Storage
     certified: "true"
-    containerImage: docker.io/dellemc/dell-csi-operator:v1.10.0
+    containerImage: docker.io/dellemc/dell-csi-operator:v1.11.0
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.11"}]'
     operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/dell/dell-csi-operator
     support: Dell Technologies
-  name: dell-csi-operator-certified.v1.10.0
+  name: dell-csi-operator-certified.v1.11.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -2057,7 +2057,7 @@ spec:
                 env:
                 - name: OPERATOR_DRIVERS
                   value: unity,powermax,isilon,vxflexos,powerstore
-                image: docker.io/dellemc/dell-csi-operator:v1.10.0
+                image: docker.io/dellemc/dell-csi-operator:v1.11.0
                 imagePullPolicy: Always
                 name: dell-csi-operator-controller
                 resources: {}
@@ -2117,8 +2117,8 @@ spec:
   minKubeVersion: 1.21.0
   provider:
     name: Dell Technologies
-  replaces: dell-csi-operator-certified.v1.9.0
+  replaces: dell-csi-operator-certified.v1.10.0
   skips:
   - dell-csi-operator-certified.v1.1.0
   - dell-csi-operator-certified.v1.2.0
-  version: 1.10.0
+  version: 1.11.0

--- a/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
+++ b/community_bundle/manifests/dell-csi-operator.clusterserviceversion.yaml
@@ -427,13 +427,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Storage
-    containerImage: docker.io/dellemc/dell-csi-operator:v1.10.0
+    containerImage: docker.io/dellemc/dell-csi-operator:v1.11.0
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.11"}]'
     operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/dell/dell-csi-operator
     support: Dell Technologies
-  name: dell-csi-operator.v1.10.0
+  name: dell-csi-operator.v1.11.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -2056,7 +2056,7 @@ spec:
                 env:
                 - name: OPERATOR_DRIVERS
                   value: unity,powermax,isilon,vxflexos,powerstore
-                image: docker.io/dellemc/dell-csi-operator:v1.10.0
+                image: docker.io/dellemc/dell-csi-operator:v1.11.0
                 imagePullPolicy: Always
                 name: dell-csi-operator-controller
                 resources: {}
@@ -2116,8 +2116,8 @@ spec:
   minKubeVersion: 1.21.0
   provider:
     name: Dell Technologies
-  replaces: dell-csi-operator.v1.9.0
+  replaces: dell-csi-operator.v1.10.0
   skips:
   - dell-csi-operator.v1.1.0
   - dell-csi-operator.v1.2.0
-  version: 1.10.0
+  version: 1.11.0

--- a/community_bundle/manifests/dell-csi-operator.package.yaml
+++ b/community_bundle/manifests/dell-csi-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-  - currentCSV: dell-csi-operator.v1.10.0
+  - currentCSV: dell-csi-operator.v1.11.0
     name: stable
 defaultChannel: stable
 packageName: dell-csi-operator

--- a/config/install/kustomization.yaml
+++ b/config/install/kustomization.yaml
@@ -14,4 +14,4 @@ bases:
 images:
   - name: controller
     newName: docker.io/dellemc/dell-csi-operator
-    newTag: v1.10.0
+    newTag: v1.11.0

--- a/config/manifests/bases/dell-csi-operator-certified.clusterserviceversion.yaml
+++ b/config/manifests/bases/dell-csi-operator-certified.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Storage
     certified: "true"
-    containerImage: docker.io/dellemc/dell-csi-operator:v1.10.0
+    containerImage: docker.io/dellemc/dell-csi-operator:v1.11.0
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.11"}]'
     operators.operatorframework.io/builder: operator-sdk-v1.15.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/dell/dell-csi-operator
     support: Dell Technologies
-  name: dell-csi-operator-certified.v1.10.0
+  name: dell-csi-operator-certified.v1.11.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1350,8 +1350,8 @@ spec:
   minKubeVersion: 1.21.0
   provider:
     name: Dell Technologies
-  replaces: dell-csi-operator-certified.v1.9.0
+  replaces: dell-csi-operator-certified.v1.10.0
   skips:
   - dell-csi-operator-certified.v1.1.0
   - dell-csi-operator-certified.v1.2.0
-  version: 1.10.0
+  version: 1.11.0

--- a/config/olm/operator_certified.yaml
+++ b/config/olm/operator_certified.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: test-olm
 spec:
   sourceType: grpc
-  image: dellemc/dellemcregistry_certified:v1.10.0
+  image: dellemc/dellemcregistry_certified:v1.11.0
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/config/olm/operator_community.yaml
+++ b/config/olm/operator_community.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: test-olm
 spec:
   sourceType: grpc
-  image: dellemc/dellemcregistry_community:v1.10.0
+  image: dellemc/dellemcregistry_community:v1.11.0
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -445,7 +445,7 @@ spec:
         env:
         - name: OPERATOR_DRIVERS
           value: unity,powermax,isilon,vxflexos,powerstore
-        image: docker.io/dellemc/dell-csi-operator:v1.10.0
+        image: docker.io/dellemc/dell-csi-operator:v1.11.0
         imagePullPolicy: Always
         name: dell-csi-operator-controller
         volumeMounts:

--- a/docker.mk
+++ b/docker.mk
@@ -30,7 +30,7 @@ OPERATOR_IMAGE ?= dell-csi-operator
 BUNDLE_IMAGE ?= csiopbundle_ops_certified
 # Default Index Image name
 INDEX_IMAGE ?= dellemcregistry_certified
-SOURCE_INDEX_IMG ?= dellemc/dell-csi-operator/dellemcregistry_certified:v1.9.0
+SOURCE_INDEX_IMG ?= dellemc/dell-csi-operator/dellemcregistry_certified:v1.10.0
 
 
 # Operator Images

--- a/scripts/build_olm_community_images.sh
+++ b/scripts/build_olm_community_images.sh
@@ -16,9 +16,9 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOTDIR="$(dirname "$SCRIPTDIR")"
 
 # This should be updated with every release
-OPERATOR_VERSION="1.10.0"
+OPERATOR_VERSION="1.11.0"
 DEFAULT_REPO=dellemc/dell-csi-operator
-SOURCE_INDEX_IMG=dellemc/dell-csi-operator/dellemcregistry_community:v1.9.0
+SOURCE_INDEX_IMG=dellemc/dell-csi-operator/dellemcregistry_community:v1.10.0
 
 # Using docker for building the images as there were some issues with podman
 command -v docker

--- a/test/controller_test.go
+++ b/test/controller_test.go
@@ -1,15 +1,17 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package controller_test
 

--- a/test/fakeclient_test.go
+++ b/test/fakeclient_test.go
@@ -1,15 +1,17 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package controller_test
 

--- a/test/integration-tests/basic_test.go
+++ b/test/integration-tests/basic_test.go
@@ -1,15 +1,17 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package integrationtest
 

--- a/test/integration-tests/main_test.go
+++ b/test/integration-tests/main_test.go
@@ -1,15 +1,17 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package integrationtest
 

--- a/test/integration-tests/powermax_test.go
+++ b/test/integration-tests/powermax_test.go
@@ -1,15 +1,17 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package integrationtest
 


### PR DESCRIPTION
# Description
Bumps up the operator version to 1.11.0

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/583 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

https://osj-sio-03-prd.cec.lab.emc.com/job/CSI-Operator/job/dell-csi-operator-sanity-k8s-v125/19/console
