### PR TITLE
SDC approval for powerflex 2.6

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -445,7 +445,7 @@ spec:
         env:
         - name: OPERATOR_DRIVERS
           value: unity,powermax,isilon,vxflexos,powerstore
-        image: docker.io/dellemc/dell-csi-operator:v1.11.0
+        #image: docker.io/dellemc/dell-csi-operator:v1.11.0
         imagePullPolicy: Always
         name: dell-csi-operator-controller
         volumeMounts:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -445,7 +445,7 @@ spec:
         env:
         - name: OPERATOR_DRIVERS
           value: unity,powermax,isilon,vxflexos,powerstore
-        #image: docker.io/dellemc/dell-csi-operator:v1.11.0
+        image: docker.io/dellemc/dell-csi-operator:v1.11.0
         imagePullPolicy: Always
         name: dell-csi-operator-controller
         volumeMounts:

--- a/driverconfig/vxflexos_v260_v123.json
+++ b/driverconfig/vxflexos_v260_v123.json
@@ -74,6 +74,14 @@
           "SetForNode": true,
           "DefaultValueForController": "false",
           "DefaultValueForNode": "false"
+        },
+        {
+          "Name": "X_CSI_APPROVE_SDC_ENABLED",
+          "CSIEnvType": "Boolean",
+          "SetForController": false,
+          "SetForNode": true,
+          "DefaultValueForController": "",
+          "DefaultValueForNode": "false"
         }
       ],
   

--- a/driverconfig/vxflexos_v260_v124.json
+++ b/driverconfig/vxflexos_v260_v124.json
@@ -74,6 +74,14 @@
           "SetForNode": true,
           "DefaultValueForController": "false",
           "DefaultValueForNode": "false"
+        },
+        {
+          "Name": "X_CSI_APPROVE_SDC_ENABLED",
+          "CSIEnvType": "Boolean",
+          "SetForController": false,
+          "SetForNode": true,
+          "DefaultValueForController": "",
+          "DefaultValueForNode": "false"
         }
       ],
   

--- a/driverconfig/vxflexos_v260_v125.json
+++ b/driverconfig/vxflexos_v260_v125.json
@@ -74,6 +74,14 @@
           "SetForNode": true,
           "DefaultValueForController": "false",
           "DefaultValueForNode": "false"
+        },
+        {
+          "Name": "X_CSI_APPROVE_SDC_ENABLED",
+          "CSIEnvType": "Boolean",
+          "SetForController": false,
+          "SetForNode": true,
+          "DefaultValueForController": "",
+          "DefaultValueForNode": "false"
         }
       ],
   

--- a/driverconfig/vxflexos_v260_v126.json
+++ b/driverconfig/vxflexos_v260_v126.json
@@ -74,9 +74,17 @@
           "SetForNode": true,
           "DefaultValueForController": "false",
           "DefaultValueForNode": "false"
+        },
+        {
+          "Name": "X_CSI_APPROVE_SDC_ENABLED",
+          "CSIEnvType": "Boolean",
+          "SetForController": false,
+          "SetForNode": true,
+          "DefaultValueForController": "",
+          "DefaultValueForNode": "false"
         }
       ],
-  
+      
       "driverArgs": [
       "--array-config=/vxflexos-config/config",
       "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"

--- a/samples/vxflex_v260_k8s_123.yaml
+++ b/samples/vxflex_v260_k8s_123.yaml
@@ -47,14 +47,6 @@ spec:
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
 
-        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
-        # Allowed values:
-        #    true: enable SDC approval
-        #    false: disable SDC approval
-        # Default value: false
-        - name: X_CSI_APPROVE_SDC_ENABLED
-          value: "false"  
-
       #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
       # Leave as blank to use all nodes
       # Allowed values: map of key-value pairs
@@ -87,6 +79,14 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
+
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"  
         
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes

--- a/samples/vxflex_v260_k8s_123.yaml
+++ b/samples/vxflex_v260_k8s_123.yaml
@@ -47,6 +47,14 @@ spec:
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
 
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"  
+
       #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
       # Leave as blank to use all nodes
       # Allowed values: map of key-value pairs

--- a/samples/vxflex_v260_k8s_124.yaml
+++ b/samples/vxflex_v260_k8s_124.yaml
@@ -74,6 +74,14 @@ spec:
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
           
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"
+            
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes
       # Allowed values: map of key-value pairs

--- a/samples/vxflex_v260_k8s_125.yaml
+++ b/samples/vxflex_v260_k8s_125.yaml
@@ -73,7 +73,15 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
-          
+
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"
+            
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes
       # Allowed values: map of key-value pairs

--- a/samples/vxflex_v260_k8s_126.yaml
+++ b/samples/vxflex_v260_k8s_126.yaml
@@ -73,7 +73,15 @@ spec:
         # Default value: false
         - name: X_CSI_HEALTH_MONITOR_ENABLED
           value: "false"
-          
+
+        # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"
+
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes
       # Allowed values: map of key-value pairs

--- a/samples/vxflex_v260_ops_410.yaml
+++ b/samples/vxflex_v260_ops_410.yaml
@@ -33,13 +33,6 @@ spec:
     
     controller:
       envs:
-      # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
-        # Allowed values:
-        #    true: enable SDC approval
-        #    false: disable SDC approval
-        # Default value: false
-        - name: X_CSI_APPROVE_SDC_ENABLED
-          value: "false"
 
       #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
       # Leave as blank to use all nodes
@@ -66,6 +59,13 @@ spec:
 
     node:
       envs:
+      # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"
 
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes

--- a/samples/vxflex_v260_ops_410.yaml
+++ b/samples/vxflex_v260_ops_410.yaml
@@ -33,6 +33,13 @@ spec:
     
     controller:
       envs:
+      # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"
 
       #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
       # Leave as blank to use all nodes

--- a/samples/vxflex_v260_ops_411.yaml
+++ b/samples/vxflex_v260_ops_411.yaml
@@ -33,14 +33,7 @@ spec:
     
     controller:
       envs:
-      # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
-        # Allowed values:
-        #    true: enable SDC approval
-        #    false: disable SDC approval
-        # Default value: false
-        - name: X_CSI_APPROVE_SDC_ENABLED
-          value: "false"
-
+      
       #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
       # Leave as blank to use all nodes
       # Allowed values: map of key-value pairs
@@ -60,6 +53,13 @@ spec:
 
     node:
       envs:
+      # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"
 
       # "node.nodeSelector" defines what nodes would be selected for pods of node daemonset
       # Leave as blank to use all nodes

--- a/samples/vxflex_v260_ops_411.yaml
+++ b/samples/vxflex_v260_ops_411.yaml
@@ -33,6 +33,13 @@ spec:
     
     controller:
       envs:
+      # X_CSI_APPROVE_SDC_ENABLED: Enables/Disable SDC approval
+        # Allowed values:
+        #    true: enable SDC approval
+        #    false: disable SDC approval
+        # Default value: false
+        - name: X_CSI_APPROVE_SDC_ENABLED
+          value: "false"
 
       #"controller.nodeSelector" defines what nodes would be selected for pods of controller deployment
       # Leave as blank to use all nodes


### PR DESCRIPTION
# Description
This PR adds support for SDC approval for Powerflex 2.6 driver

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#583

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Fresh install of dell-csi-operator with the code changes tested on OCP 4.11 and K8S 1.26 environment
- [X] Installed the Powerflex driver and ran cert-csi. The cert-csi is Successful with 100% tests passed.

[Driver logs.docx](https://github.com/dell/dell-csi-operator/files/10783108/Driver.logs.docx)

[root@kv411-bastion-10-225-2-146 ~]# kubectl logs vxflexos-node-7xb2x -n test-vxflexos -c driver
time="2023-02-20T09:00:35Z" level=info msg="configured 1b54aee56a21ab0f" allSystemNames= endpoint="https://10.225.108.171" isDefault=true password="********" skipCertificateValidation=true systemID=1b54aee56a21ab0f user=admin
time="2023-02-20T09:00:35Z" level=info msg="driver configuration file " 
time="2023-02-20T09:00:35Z" level=info msg="1b54aee56a21ab0f is the default array, skipping VolumePrefixToSystems map update. \n"
time="2023-02-20T09:00:35Z" level=info msg="array 1b54aee56a21ab0f probed successfully"
time="2023-02-20T09:00:36Z" level=info msg="set SDC GUID" guid=15513F25-8E7E-5EAA-8B25-1CA3EC75380A
time="2023-02-20T09:00:36Z" level=info msg="Approve SDC enabled"
time="2023-02-20T09:00:36Z" level=warning msg="Array RestrictedSdcMode is None, driver only supports GUID RestrictedSdcMode If SDC becomes restricted again, driver will not be able to approve"
time="2023-02-20T09:00:36Z" level=info msg="configured csi-vxflexos.dellemc.com" IsApproveSDCEnabled=true IsHealthMonitorEnabled=false IsSdcRenameEnabled=false allowRWOMultiPodAccess=false autoprobe=true mode=node privatedir=/var/lib/kubelet/plugins/vxflexos.emc.dell.com/disks sdcGUID=15513F25-8E7E-5EAA-8B25-1CA3EC75380A sdcPrefix= thickprovision=false
time="2023-02-20T09:00:36Z" level=info msg="identity service registered"
time="2023-02-20T09:00:36Z" level=info msg="node service registered"
time="2023-02-20T09:00:36Z" level=info msg="Registering additional GRPC servers"
time="2023-02-20T09:00:36Z" level=info msg=serving endpoint="unix:///var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"
time="2023-02-20T09:00:36Z" level=info msg="/csi.v1.Identity/GetPluginInfo: REQ 0001: XXX_NoUnkeyedLiteral={}, XXX_sizecache=0"
time="2023-02-20T09:00:36Z" level=info msg="/csi.v1.Identity/GetPluginInfo: REP 0001: 
